### PR TITLE
fix: issue 12 edit_file tool panics

### DIFF
--- a/src/fs_service.rs
+++ b/src/fs_service.rs
@@ -121,6 +121,16 @@ impl FileSystemService {
         })
     }
 
+    fn detect_line_ending(&self, text: &str) -> &str {
+        if text.contains("\r\n") {
+            "\r\n"
+        } else if text.contains('\r') {
+            "\r"
+        } else {
+            "\n"
+        }
+    }
+
     pub async fn zip_directory(
         &self,
         input_dir: String,
@@ -472,6 +482,7 @@ impl FileSystemService {
 
         // Read file content and normalize line endings
         let content_str = tokio::fs::read_to_string(&valid_path).await?;
+        let original_line_ending = self.detect_line_ending(&content_str);
         let content_str = normalize_line_endings(&content_str);
 
         // Apply edits sequentially
@@ -600,6 +611,7 @@ impl FileSystemService {
 
         if !is_dry_run {
             let target = save_to.unwrap_or(valid_path.as_path());
+            let modified_content = modified_content.replace("\n", original_line_ending);
             tokio::fs::write(target, modified_content).await?;
         }
 

--- a/src/fs_service/utils.rs
+++ b/src/fs_service/utils.rs
@@ -103,7 +103,7 @@ pub async fn write_zip_entry(
 }
 
 pub fn normalize_line_endings(text: &str) -> String {
-    text.replace("\r\n", "\n")
+    text.replace("\r\n", "\n").replace('\r', "\n")
 }
 
 // checks if path component is a  Prefix::VerbatimDisk


### PR DESCRIPTION
### 📌 Summary
Resolves issue #12 by improving the logic within the `apply_file_edits()` function.

### 🔍 Related Issues
<!-- Link related issues using keywords like "Fixes #123" or "Closes #456" -->

- Fixes #12 


### ✨ Changes Made

- Enhanced `apply_file_edits()` function to cover edge cases properly
- Modified the `edit_file` tool to retain original line endings across different operating systems.
