### PR TITLE
fix: improved apply_file_edits by adding bounds check for edit operation

### DIFF
--- a/src/fs_service.rs
+++ b/src/fs_service.rs
@@ -512,6 +512,19 @@ impl FileSystemService {
 
             let mut match_found = false;
 
+            // skip when the match is impossible:
+            if old_lines.len() > content_lines.len() {
+                let error_message = format!(
+                    "Cannot apply edit: the original text spans more lines ({}) than the file content ({}).",
+                    old_lines.len(),
+                    content_lines.len()
+                );
+
+                return Err(RpcError::internal_error()
+                    .with_message(error_message)
+                    .into());
+            }
+
             for i in 0..=content_lines.len() - old_lines.len() {
                 let potential_match = &content_lines[i..i + old_lines.len()];
 

--- a/src/fs_service.rs
+++ b/src/fs_service.rs
@@ -525,7 +525,8 @@ impl FileSystemService {
                     .into());
             }
 
-            for i in 0..=content_lines.len() - old_lines.len() {
+            let max_start = content_lines.len().saturating_sub(old_lines.len());
+            for i in 0..=max_start {
                 let potential_match = &content_lines[i..i + old_lines.len()];
 
                 // Compare lines with normalized whitespace


### PR DESCRIPTION
### 📌 Summary

This PR fixes a potential panic in the apply_file_edits function caused by attempting to access an out-of-range slice when the old_text in an EditOperation has more lines than the file content.

The issue was identified in #19  where a file with 2 lines and an edit with 41 lines triggered a `range end index 41 out of range for slice of length 2` panic.

### 🔍 Related Issues
<!-- Link related issues using keywords like "Fixes #123" or "Closes #456" -->

- Fixes #19


### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Added a check in apply_file_edits to verify that old_lines.len() does not exceed content_lines.len() before the line-by-line matching loop.
- Returns an Err with a descriptive message if the edit operation is too large, preventing the panic.
- Added a test case to validate the new error handling behavior.