### PR TITLE
feat: add list_directory_with_sizes MCP Tool for Directory Listing with File Sizes

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -150,6 +150,9 @@ impl ServerHandler for MyServerHandler {
             FileSystemTools::SearchFilesContentTool(params) => {
                 SearchFilesContentTool::run_tool(params, &self.fs_service).await
             }
+            FileSystemTools::ListDirectoryWithSizesTool(params) => {
+                ListDirectoryWithSizesTool::run_tool(params, &self.fs_service).await
+            }
         }
     }
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -4,6 +4,7 @@ mod edit_file;
 mod get_file_info;
 mod list_allowed_directories;
 mod list_directory;
+mod list_directory_with_sizes;
 mod move_file;
 mod read_files;
 mod read_multiple_files;
@@ -18,6 +19,7 @@ pub use edit_file::{EditFileTool, EditOperation};
 pub use get_file_info::GetFileInfoTool;
 pub use list_allowed_directories::ListAllowedDirectoriesTool;
 pub use list_directory::ListDirectoryTool;
+pub use list_directory_with_sizes::ListDirectoryWithSizesTool;
 pub use move_file::MoveFileTool;
 pub use read_files::ReadFileTool;
 pub use read_multiple_files::ReadMultipleFilesTool;
@@ -45,7 +47,8 @@ tool_box!(
         ZipFilesTool,
         UnzipFileTool,
         ZipDirectoryTool,
-        SearchFilesContentTool
+        SearchFilesContentTool,
+        ListDirectoryWithSizesTool
     ]
 );
 
@@ -68,6 +71,7 @@ impl FileSystemTools {
             | FileSystemTools::ListDirectoryTool(_)
             | FileSystemTools::ReadMultipleFilesTool(_)
             | FileSystemTools::SearchFilesContentTool(_)
+            | FileSystemTools::ListDirectoryWithSizesTool(_)
             | FileSystemTools::SearchFilesTool(_) => false,
         }
     }

--- a/src/tools/list_directory_with_sizes.rs
+++ b/src/tools/list_directory_with_sizes.rs
@@ -36,7 +36,7 @@ impl ListDirectoryWithSizesTool {
         let mut output = String::with_capacity(entries.len() * 50 + 120);
 
         // Sort entries by file name
-        entries.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+        entries.sort_by_key(|a| a.file_name());
 
         // build the output string
         for entry in &entries {
@@ -44,7 +44,7 @@ impl ListDirectoryWithSizesTool {
             let file_name = file_name.to_string_lossy();
 
             if entry.path().is_dir() {
-                writeln!(output, "[DIR]  {:<30}", file_name).map_err(CallToolError::new)?;
+                writeln!(output, "[DIR]  {file_name:<30}").map_err(CallToolError::new)?;
                 dir_count += 1;
             } else if entry.path().is_file() {
                 let metadata = entry.metadata().await.map_err(CallToolError::new)?;
@@ -65,8 +65,7 @@ impl ListDirectoryWithSizesTool {
         // Append summary
         writeln!(
             output,
-            "\nTotal: {} files, {} directories",
-            file_count, dir_count
+            "\nTotal: {file_count} files, {dir_count} directories"
         )
         .map_err(CallToolError::new)?;
         writeln!(output, "Total size: {}", format_bytes(total_size)).map_err(CallToolError::new)?;


### PR DESCRIPTION
### 📌 Summary
This pull request introduces a new MCP (Model Context Protocol) tool, `list_directory_with_sizes`, which enables AI clients to list directory contents with file sizes in a human-readable format. 
