### PR TITLE
feat!: upgrade to latest MCP protocol (2025-06-18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,12 +390,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,39 +623,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "http"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
-dependencies = [
- "bytes",
- "http",
-]
-
-[[package]]
-name = "hyper"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
-dependencies = [
- "bytes",
- "http",
- "http-body",
- "tokio",
-]
 
 [[package]]
 name = "iana-time-zone"
@@ -1002,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-macros"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375eba9388d9d5ffc8951e5f25296f9739be4e5700375ac7c74ad957a903b92b"
+checksum = "5a495ee12964fa392044792db4e9da78c94756e186a5712e5d7e625c143419ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1015,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-schema"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a794de25669a2d21c5074ec5082f74f5e88863a112339fe90264d9e480b0ee8b"
+checksum = "fec1ff3507a619b9945f60a94dac448541aef8c9803aa6192c30f4a932cb1499"
 dependencies = [
  "serde",
  "serde_json",
@@ -1025,13 +986,12 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bed508dfa638d89b1a797ddfe1b4b4022db834036b3f1bcdf2909cea5be14a2"
+checksum = "1fb7d9a1fdcf02efee5cd21a568f31c819b7f2d767c42b37cb79aab302ac5b35"
 dependencies = [
  "async-trait",
  "futures",
- "hyper",
  "rust-mcp-macros",
  "rust-mcp-schema",
  "rust-mcp-transport",
@@ -1044,9 +1004,9 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-transport"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6318216799507090512e6ffa7ea7fd26c6f2098c655cb72942dd5e221cfdea3d"
+checksum = "d7f5468b8a00e800c3d708321216439ee1ad433592d725df93668bff75436348"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ license = false
 eula = false
 
 [dependencies]
-rust-mcp-sdk = { version = "0.4", default-features = false, features = [
+rust-mcp-sdk = { version = "0.5", default-features = false, features = [
     "server",
     "macros",
-    "2025_03_26",
+    "2025_06_18",
 ] }
 
 thiserror = { version = "2.0" }

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,6 +11,7 @@ pub fn server_details() -> InitializeResult {
         server_info: Implementation {
             name: "rust-mcp-filesystem".to_string(),
             version: env!("CARGO_PKG_VERSION").to_string(),
+            title:Some("Filesystem MCP Server: fast and efficient tools for managing filesystem operations.".to_string())
         },
         capabilities: ServerCapabilities {
             experimental: None,

--- a/src/tools/create_directory.rs
+++ b/src/tools/create_directory.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use rust_mcp_sdk::macros::{mcp_tool, JsonSchema};
+use rust_mcp_sdk::schema::TextContent;
 use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 
 use crate::fs_service::FileSystemService;
@@ -33,9 +34,8 @@ impl CreateDirectoryTool {
             .await
             .map_err(CallToolError::new)?;
 
-        Ok(CallToolResult::text_content(
+        Ok(CallToolResult::text_content(vec![TextContent::from(
             format!("Successfully created directory {}", &params.path),
-            None,
-        ))
+        )]))
     }
 }

--- a/src/tools/create_directory.rs
+++ b/src/tools/create_directory.rs
@@ -8,6 +8,7 @@ use crate::fs_service::FileSystemService;
 
 #[mcp_tool(
     name = "create_directory",
+    title="Create Directory",
     description = concat!("Create a new directory or ensure a directory exists. ",
     "Can create multiple nested directories in one operation. ",
     "If the directory already exists, this operation will succeed silently. ",

--- a/src/tools/directory_tree.rs
+++ b/src/tools/directory_tree.rs
@@ -1,4 +1,5 @@
 use rust_mcp_sdk::macros::{mcp_tool, JsonSchema};
+use rust_mcp_sdk::schema::TextContent;
 use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 use serde_json::json;
 
@@ -47,6 +48,8 @@ impl DirectoryTreeTool {
         }
 
         let json_str = serde_json::to_string_pretty(&json!(entries)).map_err(CallToolError::new)?;
-        Ok(CallToolResult::text_content(json_str, None))
+        Ok(CallToolResult::text_content(vec![TextContent::from(
+            json_str,
+        )]))
     }
 }

--- a/src/tools/directory_tree.rs
+++ b/src/tools/directory_tree.rs
@@ -8,6 +8,7 @@ use crate::fs_service::FileSystemService;
 
 #[mcp_tool(
     name = "directory_tree",
+    title= "Directory Tree",
     description = concat!("Get a recursive tree view of files and directories as a JSON structure. ",
     "Each entry includes 'name', 'type' (file/directory), and 'children' for directories. ",
     "Files have no children array, while directories always have a children array (which may be empty). ",

--- a/src/tools/edit_file.rs
+++ b/src/tools/edit_file.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use rust_mcp_sdk::macros::{mcp_tool, JsonSchema};
+use rust_mcp_sdk::schema::TextContent;
 use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 
 use crate::fs_service::FileSystemService;
@@ -53,6 +54,6 @@ impl EditFileTool {
             .await
             .map_err(CallToolError::new)?;
 
-        Ok(CallToolResult::text_content(diff, None))
+        Ok(CallToolResult::text_content(vec![TextContent::from(diff)]))
     }
 }

--- a/src/tools/edit_file.rs
+++ b/src/tools/edit_file.rs
@@ -19,6 +19,7 @@ pub struct EditOperation {
 
 #[mcp_tool(
     name = "edit_file",
+    title="Edit File",
     description = concat!("Make line-based edits to a text file. ",
     "Each edit replaces exact line sequences with new content. ",
     "Returns a git-style diff showing the changes made. ",

--- a/src/tools/get_file_info.rs
+++ b/src/tools/get_file_info.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use rust_mcp_sdk::macros::{mcp_tool, JsonSchema};
+use rust_mcp_sdk::schema::TextContent;
 use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 
 use crate::fs_service::FileSystemService;
@@ -32,6 +33,8 @@ impl GetFileInfoTool {
             .get_file_stats(Path::new(&params.path))
             .await
             .map_err(CallToolError::new)?;
-        Ok(CallToolResult::text_content(stats.to_string(), None))
+        Ok(CallToolResult::text_content(vec![TextContent::from(
+            stats.to_string(),
+        )]))
     }
 }

--- a/src/tools/get_file_info.rs
+++ b/src/tools/get_file_info.rs
@@ -8,6 +8,7 @@ use crate::fs_service::FileSystemService;
 
 #[mcp_tool(
     name = "get_file_info",
+    title="Get File Info",
     description = concat!("Retrieve detailed metadata about a file or directory. ",
     "Returns comprehensive information including size, creation time, ",
     "last modified time, permissions, and type. ",

--- a/src/tools/list_allowed_directories.rs
+++ b/src/tools/list_allowed_directories.rs
@@ -6,6 +6,7 @@ use crate::fs_service::FileSystemService;
 
 #[mcp_tool(
     name = "list_allowed_directories",
+    title="List Allowed Directories",
     description = concat!("Returns a list of directories that the server has permission ",
     "to access Subdirectories within these allowed directories are also accessible. ",
     "Use this to identify which directories and their nested paths are available ",

--- a/src/tools/list_allowed_directories.rs
+++ b/src/tools/list_allowed_directories.rs
@@ -1,4 +1,5 @@
 use rust_mcp_sdk::macros::{mcp_tool, JsonSchema};
+use rust_mcp_sdk::schema::TextContent;
 use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 
 use crate::fs_service::FileSystemService;
@@ -31,6 +32,8 @@ impl ListAllowedDirectoriesTool {
                 .collect::<Vec<_>>()
                 .join("\n")
         );
-        Ok(CallToolResult::text_content(result, None))
+        Ok(CallToolResult::text_content(vec![TextContent::from(
+            result,
+        )]))
     }
 }

--- a/src/tools/list_directory.rs
+++ b/src/tools/list_directory.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use rust_mcp_sdk::macros::{mcp_tool, JsonSchema};
+use rust_mcp_sdk::schema::TextContent;
 use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 
 use crate::fs_service::FileSystemService;
@@ -47,6 +48,8 @@ impl ListDirectoryTool {
             })
             .collect();
 
-        Ok(CallToolResult::text_content(formatted.join("\n"), None))
+        Ok(CallToolResult::text_content(vec![TextContent::from(
+            formatted.join("\n"),
+        )]))
     }
 }

--- a/src/tools/list_directory.rs
+++ b/src/tools/list_directory.rs
@@ -8,6 +8,7 @@ use crate::fs_service::FileSystemService;
 
 #[mcp_tool(
     name = "list_directory",
+    title="List Directory",
     description = concat!("Get a detailed listing of all files and directories in a specified path. ",
 "Results clearly distinguish between files and directories with [FILE] and [DIR] ",
 "prefixes. This tool is essential for understanding directory structure and ",

--- a/src/tools/list_directory_with_sizes.rs
+++ b/src/tools/list_directory_with_sizes.rs
@@ -9,6 +9,7 @@ use crate::fs_service::FileSystemService;
 
 #[mcp_tool(
     name = "list_directory_with_sizes",
+    title="List Directory With File Sizes",
     description = concat!("Get a detailed listing of all files and directories in a specified path, including sizes. " ,
         "Results clearly distinguish between files and directories with [FILE] and [DIR] prefixes. " ,
         "This tool is useful for understanding directory structure and " ,

--- a/src/tools/list_directory_with_sizes.rs
+++ b/src/tools/list_directory_with_sizes.rs
@@ -1,4 +1,5 @@
 use rust_mcp_sdk::macros::{mcp_tool, JsonSchema};
+use rust_mcp_sdk::schema::TextContent;
 use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 use std::fmt::Write;
 use std::path::Path;
@@ -86,6 +87,8 @@ impl ListDirectoryWithSizesTool {
             .format_directory_entries(entries)
             .await
             .map_err(CallToolError::new)?;
-        Ok(CallToolResult::text_content(output, None))
+        Ok(CallToolResult::text_content(vec![TextContent::from(
+            output,
+        )]))
     }
 }

--- a/src/tools/move_file.rs
+++ b/src/tools/move_file.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use rust_mcp_sdk::macros::{mcp_tool, JsonSchema};
+use rust_mcp_sdk::schema::TextContent;
 use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 
 use crate::fs_service::FileSystemService;
@@ -35,12 +36,11 @@ impl MoveFileTool {
             .await
             .map_err(CallToolError::new)?;
 
-        Ok(CallToolResult::text_content(
+        Ok(CallToolResult::text_content(vec![TextContent::from(
             format!(
                 "Successfully moved {} to {}",
                 &params.source, &params.destination
             ),
-            None,
-        ))
+        )]))
     }
 }

--- a/src/tools/move_file.rs
+++ b/src/tools/move_file.rs
@@ -8,6 +8,7 @@ use crate::fs_service::FileSystemService;
 
 #[mcp_tool(
     name = "move_file",
+    title="Move File",
     description = concat!("Move or rename files and directories. Can move files between directories ",
 "and rename them in a single operation. If the destination exists, the ",
 "operation will fail. Works across different directories and can be used ",

--- a/src/tools/read_files.rs
+++ b/src/tools/read_files.rs
@@ -8,6 +8,7 @@ use crate::fs_service::FileSystemService;
 
 #[mcp_tool(
     name = "read_file",
+    title="Read File",
     description = concat!("Read the complete contents of a file from the file system. ",
     "Handles various text encodings and provides detailed error messages if the ",
     "file cannot be read. Use this tool when you need to examine the contents of ",

--- a/src/tools/read_files.rs
+++ b/src/tools/read_files.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use rust_mcp_sdk::macros::{mcp_tool, JsonSchema};
+use rust_mcp_sdk::schema::TextContent;
 use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 
 use crate::fs_service::FileSystemService;
@@ -32,6 +33,8 @@ impl ReadFileTool {
             .await
             .map_err(CallToolError::new)?;
 
-        Ok(CallToolResult::text_content(content, None))
+        Ok(CallToolResult::text_content(vec![TextContent::from(
+            content,
+        )]))
     }
 }

--- a/src/tools/read_multiple_files.rs
+++ b/src/tools/read_multiple_files.rs
@@ -9,6 +9,7 @@ use crate::fs_service::FileSystemService;
 
 #[mcp_tool(
     name = "read_multiple_files",
+    title="Read Multiple Files",
     description = concat!("Read the contents of multiple files simultaneously. ",
     "This is more efficient than reading files one by one when you need to analyze ",
     "or compare multiple files. Each file's content is returned with its ",

--- a/src/tools/read_multiple_files.rs
+++ b/src/tools/read_multiple_files.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use futures::future::join_all;
 use rust_mcp_sdk::macros::{mcp_tool, JsonSchema};
+use rust_mcp_sdk::schema::TextContent;
 use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 
 use crate::fs_service::FileSystemService;
@@ -49,6 +50,8 @@ impl ReadMultipleFilesTool {
 
         let contents = join_all(content_futures).await;
 
-        Ok(CallToolResult::text_content(contents.join("\n---\n"), None))
+        Ok(CallToolResult::text_content(vec![TextContent::from(
+            contents.join("\n---\n"),
+        )]))
     }
 }

--- a/src/tools/search_file.rs
+++ b/src/tools/search_file.rs
@@ -7,6 +7,7 @@ use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 use crate::fs_service::FileSystemService;
 #[mcp_tool(
     name = "search_files",
+    title="Search Files",
     description = concat!("Recursively search for files and directories matching a pattern. ",
   "Searches through all subdirectories from the starting path. The search ",
 "is case-insensitive and matches partial names. Returns full paths to all ",

--- a/src/tools/search_file.rs
+++ b/src/tools/search_file.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use rust_mcp_sdk::macros::{mcp_tool, JsonSchema};
+use rust_mcp_sdk::schema::TextContent;
 use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 
 use crate::fs_service::FileSystemService;
@@ -49,6 +50,8 @@ impl SearchFilesTool {
         } else {
             "No matches found".to_string()
         };
-        Ok(CallToolResult::text_content(result, None))
+        Ok(CallToolResult::text_content(vec![TextContent::from(
+            result,
+        )]))
     }
 }

--- a/src/tools/search_files_content.rs
+++ b/src/tools/search_files_content.rs
@@ -1,6 +1,7 @@
 use crate::error::ServiceError;
 use crate::fs_service::{FileSearchResult, FileSystemService};
 use rust_mcp_sdk::macros::{mcp_tool, JsonSchema};
+use rust_mcp_sdk::schema::TextContent;
 use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 use std::fmt::Write;
 #[mcp_tool(
@@ -76,10 +77,9 @@ impl SearchFilesContentTool {
                         ServiceError::FromString("No matches found in the files content.".into()),
                     )));
                 }
-                Ok(CallToolResult::text_content(
+                Ok(CallToolResult::text_content(vec![TextContent::from(
                     params.format_result(results),
-                    None,
-                ))
+                )]))
             }
             Err(err) => Ok(CallToolResult::with_error(CallToolError::new(err))),
         }

--- a/src/tools/search_files_content.rs
+++ b/src/tools/search_files_content.rs
@@ -6,6 +6,7 @@ use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 use std::fmt::Write;
 #[mcp_tool(
     name = "search_files_content",
+    title="Move Files Content",
     description = concat!("Searches for text or regex patterns in the content of files matching matching a GLOB pattern.",
                           "Returns detailed matches with file path, line number, column number and a preview of matched text.",
                           "By default, it performs a literal text search; if the 'is_regex' parameter is set to true, it performs a regular expression (regex) search instead.",

--- a/src/tools/write_file.rs
+++ b/src/tools/write_file.rs
@@ -1,4 +1,7 @@
-use rust_mcp_sdk::macros::{mcp_tool, JsonSchema};
+use rust_mcp_sdk::{
+    macros::{mcp_tool, JsonSchema},
+    schema::TextContent,
+};
 use std::path::Path;
 
 use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
@@ -32,9 +35,8 @@ impl WriteFileTool {
             .await
             .map_err(CallToolError::new)?;
 
-        Ok(CallToolResult::text_content(
+        Ok(CallToolResult::text_content(vec![TextContent::from(
             format!("Successfully wrote to {}", &params.path),
-            None,
-        ))
+        )]))
     }
 }

--- a/src/tools/write_file.rs
+++ b/src/tools/write_file.rs
@@ -9,6 +9,7 @@ use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 use crate::fs_service::FileSystemService;
 #[mcp_tool(
     name = "write_file",
+    title="Write File",
     description = concat!("Create a new file or completely overwrite an existing file with new content. ",
 "Use with caution as it will overwrite existing files without warning. ",
 "Handles text content with proper encoding. Only works within allowed directories."),

--- a/src/tools/zip_unzip.rs
+++ b/src/tools/zip_unzip.rs
@@ -6,6 +6,7 @@ use crate::fs_service::FileSystemService;
 
 #[mcp_tool(
     name = "zip_files",
+    title="Zip Files",
     description = concat!("Creates a ZIP archive by compressing files. ",
 "It takes a list of files to compress and a target path for the resulting ZIP file. ",
 "Both the source files and the target ZIP file should reside within allowed directories."),
@@ -40,6 +41,7 @@ impl ZipFilesTool {
 
 #[mcp_tool(
     name = "unzip_file",
+    title = "Unzip Files",
     description = "Extracts the contents of a ZIP archive to a specified target directory.
 It takes a source ZIP file path and a target extraction directory.
 The tool decompresses all files and directories stored in the ZIP, recreating their structure in the target location.
@@ -71,6 +73,7 @@ impl UnzipFileTool {
 
 #[mcp_tool(
     name = "zip_directory",
+    title = "Zip Directory",
     description = "Creates a ZIP archive by compressing a directory , including files and subdirectories matching a specified glob pattern.
 It takes a path to the folder and a glob pattern to identify files to compress and a target path for the resulting ZIP file.
 Both the source directory and the target ZIP file should reside within allowed directories."

--- a/src/tools/zip_unzip.rs
+++ b/src/tools/zip_unzip.rs
@@ -1,4 +1,5 @@
 use rust_mcp_sdk::macros::{mcp_tool, JsonSchema};
+use rust_mcp_sdk::schema::TextContent;
 use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResult};
 
 use crate::fs_service::FileSystemService;
@@ -31,7 +32,9 @@ impl ZipFilesTool {
             .await
             .map_err(CallToolError::new)?;
         //TODO: return resource?
-        Ok(CallToolResult::text_content(result_content, None))
+        Ok(CallToolResult::text_content(vec![TextContent::from(
+            result_content,
+        )]))
     }
 }
 
@@ -60,7 +63,9 @@ impl UnzipFileTool {
             .await
             .map_err(CallToolError::new)?;
         //TODO: return resource?
-        Ok(CallToolResult::text_content(result_content, None))
+        Ok(CallToolResult::text_content(vec![TextContent::from(
+            result_content,
+        )]))
     }
 }
 
@@ -91,6 +96,8 @@ impl ZipDirectoryTool {
             .await
             .map_err(CallToolError::new)?;
         //TODO: return resource?
-        Ok(CallToolResult::text_content(result_content, None))
+        Ok(CallToolResult::text_content(vec![TextContent::from(
+            result_content,
+        )]))
     }
 }

--- a/tests/test_tools.rs
+++ b/tests/test_tools.rs
@@ -3,7 +3,7 @@ pub mod common;
 
 use common::setup_service;
 use rust_mcp_filesystem::tools::*;
-use rust_mcp_sdk::schema::{schema_utils::CallToolError, CallToolResultContentItem};
+use rust_mcp_sdk::schema::{schema_utils::CallToolError, ContentBlock};
 use std::fs;
 
 #[tokio::test]
@@ -22,7 +22,7 @@ async fn test_create_directory_new_directory() {
     let content = call_result.content.first().unwrap();
 
     match content {
-        CallToolResultContentItem::TextContent(text_content) => {
+        ContentBlock::TextContent(text_content) => {
             assert_eq!(
                 text_content.text,
                 format!(
@@ -54,7 +54,7 @@ async fn test_create_directory_existing_directory() {
     let content = call_result.content.first().unwrap();
 
     match content {
-        CallToolResultContentItem::TextContent(text_content) => {
+        ContentBlock::TextContent(text_content) => {
             assert_eq!(
                 text_content.text,
                 format!(
@@ -85,7 +85,7 @@ async fn test_create_directory_nested() {
     let content = call_result.content.first().unwrap();
 
     match content {
-        CallToolResultContentItem::TextContent(text_content) => {
+        ContentBlock::TextContent(text_content) => {
             assert_eq!(
                 text_content.text,
                 format!(


### PR DESCRIPTION
### 📌 Summary
This update brings rust-mcp-filesystem in line with the latest MCP protocol version 2025-06-18.
This update maintains backward compatibility where possible, with a focus on seamless integration and stability.

### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Updated rust-mcp-sdk to the latest version (0.5.0)
- Updated tools annotations with new attributes introduced in 2025-06-18
- Updated CallToolResult::text_content() calls to new signature introduced in rust-mcp-sdk v0.5
- Updated tests to remain compatible with new 2025-06-18 schema
