### PR TITLE
feat: implement mcp roots protocol support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,22 +87,15 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bee399cc3a623ec5a2db2c5b90ee0190a2260241fbe0c023ac8f7bab426aaf8"
+checksum = "977eb15ea9efd848bb8a4a1a2500347ed7f0bf794edf0dc3ddcf439f43d36b23"
 dependencies = [
- "bzip2",
  "compression-codecs",
  "compression-core",
- "deflate64",
- "flate2",
  "futures-core",
  "futures-io",
- "liblzma",
- "memchr",
  "pin-project-lite",
- "zstd",
- "zstd-safe",
 ]
 
 [[package]]
@@ -160,10 +147,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.9.3"
+name = "base64"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bstr"
@@ -199,10 +192,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.34"
+version = "1.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -216,23 +210,22 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
+checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -240,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
+checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -252,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.45"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
+checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -276,18 +269,15 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7eea68f0e02c2b0aa8856e9a9478444206d4b6828728e7b0697c0f8cca265cb"
+checksum = "485abf41ac0c8047c07c87c72c8fb3eb5197f6e9d7ded615dfd1a00ae00a0f64"
 dependencies = [
  "bzip2",
  "compression-core",
  "deflate64",
  "flate2",
- "futures-core",
  "liblzma",
- "memchr",
- "pin-project-lite",
  "zstd",
  "zstd-safe",
 ]
@@ -320,27 +310,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
-name = "derive_more"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,7 +327,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -381,12 +350,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -394,6 +363,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "flate2"
@@ -527,7 +502,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.3+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -642,9 +617,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -699,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -741,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags",
  "libc",
@@ -751,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -767,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "memchr"
@@ -978,7 +953,6 @@ dependencies = [
  "async_zip",
  "chrono",
  "clap",
- "derive_more",
  "dirs",
  "futures",
  "glob",
@@ -996,9 +970,9 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-macros"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2079014c2b3dfa82a2dafd203121d5a28929102c5e003bf8d8019a60fc17e0d"
+checksum = "b647a85c9da2eaf14e67d39cb067a8157a66bd2c0dc53ef1051a84f45edfae24"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1009,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-schema"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098436b06bfa4b88b110d12a5567cf37fd454735ee67cab7eb48bdbea0dd0e57"
+checksum = "0bb65fd293dbbfabaacba1512b3948cdd9bf31ad1f2c0fed4962052b590c5c44"
 dependencies = [
  "serde",
  "serde_json",
@@ -1019,11 +993,12 @@ dependencies = [
 
 [[package]]
 name = "rust-mcp-sdk"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "720fb8f08c2b4525cf84c923a1199f326d58f82e37d9cf4bb751b9411b023cec"
+checksum = "961ec01d0bedecf488388e6b1cf04170f9badab4927061c6592ffa385c02c6c9"
 dependencies = [
  "async-trait",
+ "base64",
  "futures",
  "rust-mcp-macros",
  "rust-mcp-schema",
@@ -1033,13 +1008,14 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "rust-mcp-transport"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc874c3f07ad7aff5e5d8eab59174377b5ac0dbe2c0ef70d09efef9cdf4649b"
+checksum = "35feabc5e4667019dc262178724c94cbced6f43959af15e214b52f79243f55ed"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1061,15 +1037,15 @@ checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1101,18 +1077,28 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.225"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1121,14 +1107,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1193,15 +1180,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -1322,21 +1309,26 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "walkdir"
@@ -1356,30 +1348,40 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.3+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
 dependencies = [
  "bumpalo",
  "log",
@@ -1391,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1401,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1414,31 +1416,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "winapi-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.2.0",
  "windows-result",
  "windows-strings",
 ]
@@ -1472,21 +1474,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
-name = "windows-result"
-version = "0.3.4"
+name = "windows-link"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1505,6 +1513,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -1529,7 +1546,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -1638,9 +1655,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.0"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "zstd"
@@ -1662,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-mcp-filesystem"
 version = "0.2.2"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/rust-mcp-stack/rust-mcp-filesystem"
 authors = ["Ali Hashemi"]
 description = "Blazing-fast, asynchronous MCP server for seamless filesystem operations."
@@ -15,9 +15,10 @@ license = false
 eula = false
 
 [dependencies]
-rust-mcp-sdk = { version = "0.6", default-features = false, features = [
+rust-mcp-sdk = {version="0.7", default-features = false, features = [
     "server",
     "macros",
+    "stdio",
     "2025_06_18",
 ] }
 
@@ -25,7 +26,6 @@ thiserror = { version = "2.0" }
 dirs = "6.0"
 glob = "0.3"
 walkdir = "2.5"
-derive_more = { version = "2.0", features = ["display", "from_str"] }
 similar = "=2.7"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Rust MCP Filesystem
 
-Rust MCP Filesystem is a blazingly fast, asynchronous, and lightweight MCP (Model Context Protocol) server designed for efficient handling of various filesystem operations.  
+Rust MCP Filesystem is a blazingly fast, asynchronous, and lightweight MCP (Model Context Protocol) server designed for efficient handling of various filesystem operations.
 This project is a pure Rust rewrite of the JavaScript-based `@modelcontextprotocol/server-filesystem`, offering enhanced capabilities, improved performance, and a robust feature set tailored for modern filesystem interactions.
 
 🚀 Refer to the [project documentation](https://rust-mcp-stack.github.io/rust-mcp-filesystem) for installation and configuration instructions.
@@ -14,8 +14,9 @@ This project is a pure Rust rewrite of the JavaScript-based `@modelcontextprotoc
 - **⚡ High Performance**: Built in Rust for speed and efficiency, leveraging asynchronous I/O to handle filesystem operations seamlessly.
 - **🔒 Read-Only by Default**: Starts with no write access, ensuring safety until explicitly configured otherwise.
 - **🔍 Advanced Glob Search**: Supports full glob pattern matching allowing precise filtering of files and directories using standard glob syntax.For example, patterns like `*.rs`, `src/**/*.txt`, and `logs/error-???.log` are valid and can be used to match specific file types, recursive directory searches, or patterned filenames.
-- **📁 Nested Directories**: Improved directory creation, allowing the creation of nested directories.
-- **📦 Lightweight**: Standalone with no external dependencies (e.g., no Node.js, Python etc required), compiled to a single binary with a minimal resource footprint, ideal for both lightweight and extensive deployment scenarios.
+- **🔄 MCP Roots support**: enabling clients to dynamically modify the list of allowed directories (disabled by default).
+- **📦 ZIP Archive Support**: Tools to create ZIP archives from files or directories and extract ZIP files with ease.
+- **🪶 Lightweight**: Standalone with no external dependencies (e.g., no Node.js, Python etc required), compiled to a single binary with a minimal resource footprint, ideal for both lightweight and extensive deployment scenarios.
 
 #### 👉 Refer to [capabilities](https://rust-mcp-stack.github.io/rust-mcp-filesystem/#/capabilities) for a full list of tools and other capabilities.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Rust MCP Filesystem
 
-Rust MCP Filesystem is a blazingly fast, asynchronous, and lightweight MCP (Model Context Protocol) server designed for efficient handling of various filesystem operations.  
+Rust MCP Filesystem is a blazingly fast, asynchronous, and lightweight MCP (Model Context Protocol) server designed for efficient handling of various filesystem operations.
 This project is a pure Rust rewrite of the JavaScript-based **@modelcontextprotocol/server-filesystem**, offering enhanced capabilities, improved performance, and a robust feature set tailored for modern filesystem interactions.
 
 Refer to the [quickstart](quickstart.md) guide for installation and configuration instructions.
@@ -9,7 +9,8 @@ Refer to the [quickstart](quickstart.md) guide for installation and configuratio
 
 - **⚡ High Performance**: Built in Rust for speed and efficiency, leveraging asynchronous I/O to handle filesystem operations seamlessly.
 - **🔒 Read-Only by Default**: Starts with no write access, ensuring safety until explicitly configured otherwise.
-- **🔍 Advanced Glob Search**: Full glob pattern matching for precise file and directory filtering (e.g., `*.rs`, `src/**/*.txt`, `logs/error-???.log`).
+- **🔍 Advanced Glob Search**: Supports full glob pattern matching allowing precise filtering of files and directories using standard glob syntax.For example, patterns like `*.rs`, `src/**/*.txt`, and `logs/error-???.log` are valid and can be used to match specific file types, recursive directory searches, or patterned filenames.
+- **🔄 MCP Roots support**: enabling clients to dynamically modify the list of allowed directories (disabled by default).
 - **📦 ZIP Archive Support**: Tools to create ZIP archives from files or directories and extract ZIP files with ease.
 - **🪶 Lightweight**: Standalone with no external dependencies (e.g., no Node.js, Python etc required), compiled to a single binary with a minimal resource footprint, ideal for both lightweight and extensive deployment scenarios.
 

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -14,7 +14,8 @@
 
 - 🪶 Lightweight
 - ⚡ High Performance
-- 🔒 Read-Only by Default
+- 🔒 Secure by design
+- 🔧 Packed with powerful tools
 
 [GitHub](https://github.com/rust-mcp-stack/rust-mcp-filesystem)
 [⚙️ Capabilities](capabilities.md)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.89.0"
 components = ["rustfmt", "clippy"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,19 +3,37 @@ use clap::{arg, command, Parser};
 #[derive(Parser, Debug)]
 #[command(name =  env!("CARGO_PKG_NAME"))]
 #[command(version = env!("CARGO_PKG_VERSION"))]
-#[command(about = "A lightning-fast, asynchronous, and lightweight MCP server designed for efficient handling of various filesystem operations", 
+#[command(about = "A lightning-fast, asynchronous, and lightweight MCP server designed for efficient handling of various filesystem operations",
 long_about = None)]
 pub struct CommandArguments {
     #[arg(
         short = 'w',
         long,
-        help = "Enables read/write mode for the app, allowing both reading and writing."
+        help = "Enables read/write mode for the app, allowing both reading and writing. Defaults to disabled."
     )]
     pub allow_write: bool,
     #[arg(
-        help = "List of directories that are permitted for the operation.",
+        help = "List of directories that are permitted for the operation. It is required when 'enable-roots' is not provided OR client does not support Roots.",
         long_help = concat!("Provide a space-separated list of directories that are permitted for the operation.\nThis list allows multiple directories to be provided.\n\nExample:  ", env!("CARGO_PKG_NAME"), " /path/to/dir1 /path/to/dir2 /path/to/dir3"),
-        required = true
+        required = false
     )]
     pub allowed_directories: Vec<String>,
+
+    #[arg(
+        short = 't',
+        long,
+        help = "Enables dynamic directory access control via Roots from the MCP client side. Defaults to disabled.\nWhen enabled, MCP clients that support Roots can dynamically update the allowed directories.\nAny directories provided by the client will completely replace the initially configured allowed directories on the server."
+    )]
+    pub enable_roots: bool,
+}
+
+impl CommandArguments {
+    pub fn validate(&self) -> Result<(), String> {
+        if !self.enable_roots && self.allowed_directories.is_empty() {
+            return Err(
+                format!(" <ALLOWED_DIRECTORIES> is required when `--enable-roots` is not provided.\n Run `{} --help` to view the usage instructions.",env!("CARGO_PKG_NAME"))
+            );
+        }
+        Ok(())
+    }
 }

--- a/src/fs_service.rs
+++ b/src/fs_service.rs
@@ -140,6 +140,12 @@ impl FileSystemService {
         requested_path: &Path,
         allowed_directories: Arc<Vec<PathBuf>>,
     ) -> ServiceResult<PathBuf> {
+        if allowed_directories.is_empty() {
+            return Err(ServiceError::FromString(format!(
+                "Allowed directories list is empty. Client did not provide any valid root directories."
+            )));
+        }
+
         // Expand ~ to home directory
         let expanded_path = expand_home(requested_path.to_path_buf());
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -6,6 +6,7 @@ use crate::error::ServiceError;
 use crate::{error::ServiceResult, fs_service::FileSystemService, tools::*};
 use async_trait::async_trait;
 use rust_mcp_sdk::mcp_server::ServerHandler;
+use rust_mcp_sdk::schema::RootsListChangedNotification;
 use rust_mcp_sdk::schema::{
     schema_utils::CallToolError, CallToolRequest, CallToolResult, InitializeRequest,
     InitializeResult, ListToolsRequest, ListToolsResult, RpcError,
@@ -53,7 +54,7 @@ impl FileSystemHandler {
 
         let sub_message: String;
 
-        let allowed_directories = self.fs_service.allowed_directories();
+        let allowed_directories = self.fs_service.allowed_directories().await;
         if allowed_directories.is_empty() && self.mcp_roots_support {
             sub_message = "No allowed directories is set - waiting for client to provide roots via MCP protocol...".to_string();
         } else {
@@ -72,8 +73,8 @@ impl FileSystemHandler {
 
     pub(crate) async fn update_allowed_directories(&self, runtime: Arc<dyn McpServer>) {
         // if client does not support roots
+        let allowed_directories = self.fs_service.allowed_directories().await;
         if !runtime.client_supports_root_list().unwrap_or(false) {
-            let allowed_directories = self.fs_service.allowed_directories();
             if !allowed_directories.is_empty() {
                 let _ = runtime.stderr_message(format!("Client does not support MCP Roots, using allowed directories set from server args:\n{}", allowed_directories
                     .iter()
@@ -84,10 +85,10 @@ impl FileSystemHandler {
                 // let message = "Server cannot operate: No allowed directories available. Server was started without command-line directories and client either does not support MCP roots protocol or provided empty roots. Please either: 1) Start server with directory arguments, or 2) Use a client that supports MCP roots protocol and provides valid root directories.";
                 let message = "Server cannot operate: No allowed directories available. Server was started without command-line directories and client does not support MCP roots protocol. Please either: 1) Start server with directory arguments, or 2) Use a client that supports MCP roots protocol and provides valid root directories.";
                 let _ = runtime.stderr_message(message.to_string()).await;
-                // runtime.shutdown().await;
             }
         } else {
             let fs_service = self.fs_service.clone();
+            let mcp_roots_support = self.mcp_roots_support;
             // retreive roots from the client and update the allowed dirctories accordingly
             tokio::spawn(async move {
                 let roots = match runtime.clone().list_roots(None).await {
@@ -113,11 +114,21 @@ impl FileSystemHandler {
                     valid_roots
                 };
 
-                if valid_roots.is_empty() {
-                    let message = "Server cannot operate: No allowed directories available. Server was started without command-line directories and client provided empty roots. Please either: 1) Start server with directory arguments, or 2) Use a client that supports MCP roots protocol and provides valid root directories.";
+                if valid_roots.is_empty() && !mcp_roots_support {
+                    let message = if allowed_directories.is_empty() {
+                        "Server cannot operate: No allowed directories available. Server was started without command-line directories and client provided empty roots. Please either: 1) Start server with directory arguments, or 2) Use a client that supports MCP roots protocol and provides valid root directories."
+                    } else {
+                        "Client provided empty roots. Allowed directories passed from command-line will be used."
+                    };
                     let _ = runtime.stderr_message(message.to_string()).await;
                 } else {
-                    fs_service.update_allowed_paths(valid_roots);
+                    let num_valid_roots = valid_roots.len();
+
+                    fs_service.update_allowed_paths(valid_roots).await;
+                    let message = format!(
+                        "Updated allowed directories from MCP roots: {num_valid_roots} valid directories",
+                    );
+                    let _ = runtime.stderr_message(message.to_string()).await;
                 }
             });
         }
@@ -128,6 +139,15 @@ impl ServerHandler for FileSystemHandler {
     async fn on_initialized(&self, runtime: Arc<dyn McpServer>) {
         let _ = runtime.stderr_message(self.startup_message().await).await;
         self.update_allowed_directories(runtime).await;
+    }
+
+    async fn handle_roots_list_changed_notification(
+        &self,
+        _notification: RootsListChangedNotification,
+        runtime: Arc<dyn McpServer>,
+    ) -> std::result::Result<(), RpcError> {
+        self.update_allowed_directories(runtime).await;
+        Ok(())
     }
 
     async fn handle_list_tools_request(

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -52,21 +52,19 @@ impl FileSystemHandler {
             },
         );
 
-        let sub_message: String;
-
         let allowed_directories = self.fs_service.allowed_directories().await;
-        if allowed_directories.is_empty() && self.mcp_roots_support {
-            sub_message = "No allowed directories is set - waiting for client to provide roots via MCP protocol...".to_string();
+        let sub_message: String = if allowed_directories.is_empty() && self.mcp_roots_support {
+            "No allowed directories is set - waiting for client to provide roots via MCP protocol...".to_string()
         } else {
-            sub_message = format!(
+            format!(
                 "Allowed directories:\n{}",
                 allowed_directories
                     .iter()
                     .map(|p| p.display().to_string())
                     .collect::<Vec<String>>()
                     .join(",\n")
-            );
-        }
+            )
+        };
 
         format!("{common_message}\n{sub_message}")
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,16 @@
 use clap::Parser;
-use rust_mcp_filesystem::{cli, error::ServiceResult, server};
+use rust_mcp_filesystem::{cli, server};
 
 #[tokio::main]
-async fn main() -> ServiceResult<()> {
-    server::start_server(cli::CommandArguments::parse()).await
+async fn main() {
+    let arguments = cli::CommandArguments::parse();
+    if let Err(err) = arguments.validate() {
+        eprintln!("Error: {err}");
+        return;
+    };
+
+    if let Err(error) = server::start_server(arguments).await {
+        eprintln!("{error}");
+    }
+    println!(">>> 90 {:?} ", 90);
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,7 +4,8 @@ use rust_mcp_sdk::schema::{
 };
 use rust_mcp_sdk::{mcp_server::server_runtime, McpServer, StdioTransport, TransportOptions};
 
-use crate::{cli::CommandArguments, error::ServiceResult, handler::MyServerHandler};
+use crate::handler::FileSystemHandler;
+use crate::{cli::CommandArguments, error::ServiceResult};
 
 pub fn server_details() -> InitializeResult {
     InitializeResult {
@@ -30,7 +31,7 @@ pub fn server_details() -> InitializeResult {
 pub async fn start_server(args: CommandArguments) -> ServiceResult<()> {
     let transport = StdioTransport::new(TransportOptions::default())?;
 
-    let handler = MyServerHandler::new(&args)?;
+    let handler = FileSystemHandler::new(&args)?;
     let server = server_runtime::create_server(server_details(), transport, handler);
 
     server.start().await?;

--- a/src/tools/directory_tree.rs
+++ b/src/tools/directory_tree.rs
@@ -33,12 +33,16 @@ impl DirectoryTreeTool {
         context: &FileSystemService,
     ) -> std::result::Result<CallToolResult, CallToolError> {
         let mut entry_counter: usize = 0;
+
+        let allowed_directories = context.allowed_directories().await;
+
         let (entries, reached_max_depth) = context
             .directory_tree(
                 params.path,
                 params.max_depth.map(|v| v as usize),
                 None,
                 &mut entry_counter,
+                allowed_directories,
             )
             .map_err(CallToolError::new)?;
 

--- a/src/tools/list_allowed_directories.rs
+++ b/src/tools/list_allowed_directories.rs
@@ -28,6 +28,7 @@ impl ListAllowedDirectoriesTool {
             "Allowed directories:\n{}",
             context
                 .allowed_directories()
+                .await
                 .iter()
                 .map(|entry| entry.display().to_string())
                 .collect::<Vec<_>>()

--- a/src/tools/list_allowed_directories.rs
+++ b/src/tools/list_allowed_directories.rs
@@ -24,16 +24,20 @@ impl ListAllowedDirectoriesTool {
         _: Self,
         context: &FileSystemService,
     ) -> std::result::Result<CallToolResult, CallToolError> {
-        let result = format!(
-            "Allowed directories:\n{}",
-            context
-                .allowed_directories()
-                .await
-                .iter()
-                .map(|entry| entry.display().to_string())
-                .collect::<Vec<_>>()
-                .join("\n")
-        );
+        let allowed_directories = context.allowed_directories().await;
+
+        let result = if allowed_directories.is_empty() {
+            "Allowed directories list is empty!".to_string()
+        } else {
+            format!(
+                "Allowed directories:\n{}",
+                allowed_directories
+                    .iter()
+                    .map(|entry| entry.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        };
         Ok(CallToolResult::text_content(vec![TextContent::from(
             result,
         )]))

--- a/src/tools/search_file.rs
+++ b/src/tools/search_file.rs
@@ -41,6 +41,7 @@ impl SearchFilesTool {
                 params.pattern,
                 params.exclude_patterns.unwrap_or_default(),
             )
+            .await
             .map_err(CallToolError::new)?;
 
         let result = if !list.is_empty() {

--- a/src/tools/search_files_content.rs
+++ b/src/tools/search_files_content.rs
@@ -65,13 +65,16 @@ impl SearchFilesContentTool {
         context: &FileSystemService,
     ) -> std::result::Result<CallToolResult, CallToolError> {
         let is_regex = params.is_regex.unwrap_or_default();
-        match context.search_files_content(
-            &params.path,
-            &params.pattern,
-            &params.query,
-            is_regex,
-            params.exclude_patterns.to_owned(),
-        ) {
+        match context
+            .search_files_content(
+                &params.path,
+                &params.pattern,
+                &params.query,
+                is_regex,
+                params.exclude_patterns.to_owned(),
+            )
+            .await
+        {
             Ok(results) => {
                 if results.is_empty() {
                     return Ok(CallToolResult::with_error(CallToolError::new(

--- a/tests/common/common.rs
+++ b/tests/common/common.rs
@@ -2,6 +2,7 @@ use std::{
     fs::{self, File},
     io::Write,
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 use clap::Parser;
@@ -18,7 +19,7 @@ pub fn get_temp_dir() -> PathBuf {
 }
 
 // Helper to create a FileSystemService with temporary directories
-pub fn setup_service(dirs: Vec<String>) -> (PathBuf, FileSystemService) {
+pub fn setup_service(dirs: Vec<String>) -> (PathBuf, FileSystemService, Arc<Vec<PathBuf>>) {
     let temp_dir = get_temp_dir();
     let allowed_dirs = dirs
         .into_iter()
@@ -30,7 +31,8 @@ pub fn setup_service(dirs: Vec<String>) -> (PathBuf, FileSystemService) {
         })
         .collect::<Vec<String>>();
     let service = FileSystemService::try_new(&allowed_dirs).unwrap();
-    (temp_dir, service)
+    let allowed_dirs: Vec<PathBuf> = allowed_dirs.iter().map(|i| i.into()).collect();
+    (temp_dir, service, Arc::new(allowed_dirs))
 }
 
 // Helper to create a temporary file

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -38,11 +38,15 @@ fn test_parse_with_write_flag_long() {
 #[test]
 fn test_missing_required_directories() {
     let args = ["mcp-server"];
+
+    // parse should pass
     let result = parse_args(&args);
-    assert!(result.is_err());
-    if let Err(e) = result {
-        assert_eq!(e.kind(), clap::error::ErrorKind::MissingRequiredArgument);
-    }
+    assert!(result.is_ok());
+
+    let result = result.unwrap().validate();
+    assert!(
+        matches!(result, Err(message) if message.contains("is required when `--enable-roots` is not provided"))
+    );
 }
 
 #[test]

--- a/tests/test_tools.rs
+++ b/tests/test_tools.rs
@@ -8,7 +8,7 @@ use std::fs;
 
 #[tokio::test]
 async fn test_create_directory_new_directory() {
-    let (temp_dir, service) = setup_service(vec!["dir1".to_string()]);
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
     let new_dir = temp_dir.join("dir1").join("new_dir");
     let params = CreateDirectoryTool {
         path: new_dir.to_str().unwrap().to_string(),
@@ -39,7 +39,7 @@ async fn test_create_directory_new_directory() {
 
 #[tokio::test]
 async fn test_create_directory_existing_directory() {
-    let (temp_dir, service) = setup_service(vec!["dir1".to_string()]);
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
     let existing_dir = temp_dir.join("dir1").join("existing_dir");
     fs::create_dir_all(&existing_dir).unwrap();
     let params = CreateDirectoryTool {
@@ -71,7 +71,7 @@ async fn test_create_directory_existing_directory() {
 
 #[tokio::test]
 async fn test_create_directory_nested() {
-    let (temp_dir, service) = setup_service(vec!["dir1".to_string()]);
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
     let nested_dir = temp_dir.join("dir1").join("nested/subdir");
     let params = CreateDirectoryTool {
         path: nested_dir.to_str().unwrap().to_string(),
@@ -100,7 +100,7 @@ async fn test_create_directory_nested() {
 
 #[tokio::test]
 async fn test_create_directory_outside_allowed() {
-    let (temp_dir, service) = setup_service(vec!["dir1".to_string()]);
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
     let outside_dir = temp_dir.join("dir2").join("forbidden");
     let params = CreateDirectoryTool {
         path: outside_dir.to_str().unwrap().to_string(),
@@ -115,7 +115,7 @@ async fn test_create_directory_outside_allowed() {
 
 #[tokio::test]
 async fn test_create_directory_invalid_path() {
-    let (temp_dir, service) = setup_service(vec!["dir1".to_string()]);
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
     let invalid_path = temp_dir.join("dir1").join("invalid\0dir");
     let params = CreateDirectoryTool {
         path: invalid_path


### PR DESCRIPTION
### 📌 Summary
This PR implements MCP Roots protocol support in the filesystem server to allow runtime updates to client directory access, no server restart required.

👉  To avoid unintentional access, this feature is off by default and must be deliberately enabled with the --enable-roots flag.


### 🔍 Related Issues
<!-- Link related issues using keywords like "Fixes #123" or "Closes #456" -->

- #34 


### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Introduced `--enable-roots` flag to enable client to be able to update list of the  allowed directories
- Updated Rust edition and toolchain
- Upgraded to the [rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk) [v0.7](https://github.com/rust-mcp-stack/rust-mcp-sdk/releases/tag/rust-mcp-sdk-v0.7.0)


