### PR TITLE
feat: support environment variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ glob = "0.3"
 walkdir = "2.5"
 similar = "=2.7"
 chrono = "0.4"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive","env"] }
 tokio = "1.4"
 serde = "1.0"
 serde_json = "1.0"

--- a/docs/_configs/claude-desktop.md
+++ b/docs/_configs/claude-desktop.md
@@ -35,7 +35,9 @@ Incorporate the following into your `claude_desktop_config.json`, based on your 
 
 ## Running via Docker
 
-**Note:** In the example below, all allowed directories are mounted to `/projects`, and `/projects` is passed as the allowed directory argument to the server CLI. You can modify this as needed to fit your requirements.
+**Note:** In the example below, all allowed directories are mounted to `/projects`,  and `/projects` is passed as the allowed directory argument to the server CLI. You can modify this as needed to fit your requirements.
+
+`ALLOW_WRITE` and `ENABLE_ROOTS` environments could be used to enable write and MCP Roots support.
 
 ```json
 {
@@ -46,6 +48,10 @@ Incorporate the following into your `claude_desktop_config.json`, based on your 
         "run",
         "-i",
         "--rm",
+        "-e",
+        "ALLOW_WRITE=false",
+        "-e",
+        "ENABLE_ROOTS=false",
         "--mount",
         "type=bind,src=/Users/username/Documents,dst=/projects/Documents",
         "--mount",

--- a/docs/guide/cli-command-options.md
+++ b/docs/guide/cli-command-options.md
@@ -11,13 +11,21 @@ Arguments:
           Example:  rust-mcp-filesystem /path/to/dir1 /path/to/dir2 /path/to/dir3
 
 Options:
-  -w, --allow-write
-          Enables read/write mode for the app, allowing both reading and writing. Defaults to disabled.
+  -w, --allow-write [<ALLOW_WRITE>]
+          Enables write mode for the app, allowing both reading and writing. Defaults to disabled.
 
-  -t, --enable-roots
+          [env: ALLOW_WRITE=]
+          [default: false]
+          [possible values: true, false]
+
+  -t, --enable-roots [<ENABLE_ROOTS>]
           Enables dynamic directory access control via Roots from the MCP client side. Defaults to disabled.
           When enabled, MCP clients that support Roots can dynamically update the allowed directories.
           Any directories provided by the client will completely replace the initially configured allowed directories on the server.
+
+          [env: ENABLE_ROOTS=true]
+          [default: false]
+          [possible values: true, false]
 
   -h, --help
           Print help (see a summary with '-h')

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,22 +9,31 @@ pub struct CommandArguments {
     #[arg(
         short = 'w',
         long,
-        help = "Enables read/write mode for the app, allowing both reading and writing. Defaults to disabled."
+        action = clap::ArgAction::SetTrue,
+        num_args = 0..=1,
+        value_parser = clap::value_parser!(bool),
+        help = "Enables write mode for the app, allowing both reading and writing. Defaults to disabled.",
+        env = "ALLOW_WRITE"
     )]
     pub allow_write: bool,
+
+    #[arg(
+        short = 't',
+        long,
+        help = "Enables dynamic directory access control via Roots from the MCP client side. Defaults to disabled.\nWhen enabled, MCP clients that support Roots can dynamically update the allowed directories.\nAny directories provided by the client will completely replace the initially configured allowed directories on the server.",
+        action = clap::ArgAction::SetTrue,
+        num_args = 0..=1,
+        value_parser = clap::value_parser!(bool),
+        env = "ENABLE_ROOTS"
+    )]
+    pub enable_roots: bool,
+
     #[arg(
         help = "List of directories that are permitted for the operation. It is required when 'enable-roots' is not provided OR client does not support Roots.",
         long_help = concat!("Provide a space-separated list of directories that are permitted for the operation.\nThis list allows multiple directories to be provided.\n\nExample:  ", env!("CARGO_PKG_NAME"), " /path/to/dir1 /path/to/dir2 /path/to/dir3"),
         required = false
     )]
     pub allowed_directories: Vec<String>,
-
-    #[arg(
-        short = 't',
-        long,
-        help = "Enables dynamic directory access control via Roots from the MCP client side. Defaults to disabled.\nWhen enabled, MCP clients that support Roots can dynamically update the allowed directories.\nAny directories provided by the client will completely replace the initially configured allowed directories on the server."
-    )]
-    pub enable_roots: bool,
 }
 
 impl CommandArguments {


### PR DESCRIPTION
### 📌 Summary
Add support for setting CLI flags via environment variables:

ALLOW_WRITE=true → enables the --allow-write flag
ENABLE_ROOTS=true → enables the --enable-roots flag

This allows configuration through environment variables in addition to command-line arguments.
