### PR TITLE
Extends file edit tool with regex support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,10 +1059,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.4.11"
+name = "regex"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1090,6 +1102,7 @@ dependencies = [
  "grep",
  "infer",
  "rayon",
+ "regex",
  "rust-mcp-sdk",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ futures = "0.3"
 tokio-util = "0.7"
 async_zip = { version = "0.0", features = ["full"] }
 grep = "0.3"
+regex = "1.11"
 base64 =  "0.22"
 infer = "0.19.0"
 rayon = "1.11.0"

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -24,7 +24,7 @@ mod zip_unzip;
 pub use calculate_directory_size::{CalculateDirectorySize, FileSizeOutputFormat};
 pub use create_directory::CreateDirectory;
 pub use directory_tree::DirectoryTree;
-pub use edit_file::{EditFile, EditOperation};
+pub use edit_file::{EditFile, EditOperation, RegexEditOptions};
 pub use find_duplicate_files::FindDuplicateFiles;
 pub use find_empty_directories::FindEmptyDirectories;
 pub use get_file_info::GetFileInfo;

--- a/src/tools/edit_file.rs
+++ b/src/tools/edit_file.rs
@@ -7,21 +7,65 @@ use rust_mcp_sdk::schema::{CallToolResult, schema_utils::CallToolError};
 use crate::fs_service::FileSystemService;
 
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug, JsonSchema)]
+#[serde(untagged)]
 /// Represents a text replacement operation.
-pub struct EditOperation {
-    /// Text to search for - must match exactly.
-    #[serde(rename = "oldText")]
-    pub old_text: String,
-    #[serde(rename = "newText")]
-    /// Text to replace the matched text with.
-    pub new_text: String,
+/// Supports two modes: exact matching (oldText/newText) or regex matching (pattern/replacement).
+pub enum EditOperation {
+    /// Exact text matching mode
+    Exact {
+        /// Text to search for - must match exactly.
+        #[serde(rename = "oldText")]
+        old_text: String,
+        /// Text to replace the matched text with.
+        #[serde(rename = "newText")]
+        new_text: String,
+    },
+    /// Regular expression matching mode
+    Regex {
+        /// Regular expression pattern to find the text to replace.
+        pattern: String,
+        /// Text to replace the matched text with (can use capture groups $1, $2, etc.).
+        replacement: String,
+        /// Optional regex options
+        #[serde(skip_serializing_if = "Option::is_none")]
+        options: Option<RegexEditOptions>,
+    },
+}
+
+#[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug, JsonSchema)]
+/// Options for regex-based edits
+pub struct RegexEditOptions {
+    /// If true, the regex is case-insensitive (default: false)
+    #[serde(
+        rename = "caseInsensitive",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub case_insensitive: Option<bool>,
+    /// If true, ^ and $ match line boundaries instead of string boundaries (default: false)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub multiline: Option<bool>,
+    /// If true, the dot (.) matches newlines as well (default: false)
+    #[serde(
+        rename = "dotAll",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub dot_all: Option<bool>,
+    /// Maximum number of replacements (0 = unlimited, default: 0)
+    #[serde(
+        rename = "maxReplacements",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub max_replacements: Option<u32>,
 }
 
 #[mcp_tool(
     name = "edit_file",
     title="Edit file",
-    description = concat!("Make line-based edits to a text file. ",
-    "Each edit replaces exact line sequences with new content. ",
+    description = concat!("Make line-based edits to a text file with support for exact matching or regular expressions. ",
+    "Each edit can use either exact text matching (oldText/newText) or regex patterns (pattern/replacement). ",
     "Returns a git-style diff showing the changes made. ",
     "Only works within allowed directories."),
     destructive_hint = false,
@@ -43,6 +87,13 @@ pub struct EditFile {
         skip_serializing_if = "std::option::Option::is_none"
     )]
     pub dry_run: Option<bool>,
+    /// Optional line range to restrict edits (format: "start-end" or "start:end")
+    #[serde(
+        rename = "lineRange",
+        default,
+        skip_serializing_if = "std::option::Option::is_none"
+    )]
+    pub line_range: Option<String>,
 }
 
 impl EditFile {
@@ -51,7 +102,13 @@ impl EditFile {
         context: &FileSystemService,
     ) -> std::result::Result<CallToolResult, CallToolError> {
         let diff = context
-            .apply_file_edits(Path::new(&params.path), params.edits, params.dry_run, None)
+            .apply_file_edits(
+                Path::new(&params.path),
+                params.edits,
+                params.dry_run,
+                None,
+                params.line_range,
+            )
             .await
             .map_err(CallToolError::new)?;
 

--- a/tests/test_edit_regex.rs
+++ b/tests/test_edit_regex.rs
@@ -1,0 +1,320 @@
+#[path = "common/common.rs"]
+pub mod common;
+
+use common::create_temp_file;
+use common::setup_service;
+use rust_mcp_filesystem::tools::{EditOperation, RegexEditOptions};
+use std::fs;
+
+/// Test simple regex replacement
+#[tokio::test]
+async fn test_regex_edit_simple() {
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let file_path = create_temp_file(
+        temp_dir.join("dir1").as_path(),
+        "test.js",
+        "function test() {\n  console.log('hello');\n}",
+    );
+
+    let edits = vec![EditOperation::Regex {
+        pattern: r"function\s+(\w+)".to_string(),
+        replacement: "async function $1".to_string(),
+        options: None,
+    }];
+
+    let result = service
+        .apply_file_edits(&file_path, edits, Some(false), None, None)
+        .await
+        .unwrap();
+
+    assert!(result.contains("-function test"));
+    assert!(result.contains("+async function test"));
+
+    let new_content = tokio::fs::read_to_string(&file_path).await.unwrap();
+    assert!(new_content.contains("async function test"));
+}
+
+/// Test regex with case insensitive option
+#[tokio::test]
+async fn test_regex_edit_case_insensitive() {
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let file_path = create_temp_file(
+        temp_dir.join("dir1").as_path(),
+        "test.txt",
+        "Hello World\nHELLO WORLD\nhello world",
+    );
+
+    let edits = vec![EditOperation::Regex {
+        pattern: "hello".to_string(),
+        replacement: "Hi".to_string(),
+        options: Some(RegexEditOptions {
+            case_insensitive: Some(true),
+            multiline: None,
+            dot_all: None,
+            max_replacements: None,
+        }),
+    }];
+
+    let result = service
+        .apply_file_edits(&file_path, edits, Some(false), None, None)
+        .await
+        .unwrap();
+
+    let new_content = fs::read_to_string(&file_path).unwrap();
+    assert_eq!(new_content, "Hi World\nHi WORLD\nHi world");
+}
+
+/// Test regex with max replacements
+#[tokio::test]
+async fn test_regex_edit_max_replacements() {
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let file_path = create_temp_file(
+        temp_dir.join("dir1").as_path(),
+        "test.txt",
+        "foo bar foo baz foo",
+    );
+
+    let edits = vec![EditOperation::Regex {
+        pattern: "foo".to_string(),
+        replacement: "FOO".to_string(),
+        options: Some(RegexEditOptions {
+            case_insensitive: None,
+            multiline: None,
+            dot_all: None,
+            max_replacements: Some(2),
+        }),
+    }];
+
+    let result = service
+        .apply_file_edits(&file_path, edits, Some(false), None, None)
+        .await
+        .unwrap();
+
+    let new_content = fs::read_to_string(&file_path).unwrap();
+    // Should replace only first 2 occurrences
+    assert_eq!(new_content, "FOO bar FOO baz foo");
+}
+
+/// Test regex with multiline mode
+#[tokio::test]
+async fn test_regex_edit_multiline() {
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let file_path = create_temp_file(
+        temp_dir.join("dir1").as_path(),
+        "test.txt",
+        "line1\nline2\nline3",
+    );
+
+    let edits = vec![EditOperation::Regex {
+        pattern: "^line".to_string(),
+        replacement: "LINE".to_string(),
+        options: Some(RegexEditOptions {
+            case_insensitive: None,
+            multiline: Some(true),
+            dot_all: None,
+            max_replacements: None,
+        }),
+    }];
+
+    let result = service
+        .apply_file_edits(&file_path, edits, Some(false), None, None)
+        .await
+        .unwrap();
+
+    let new_content = fs::read_to_string(&file_path).unwrap();
+    assert_eq!(new_content, "LINE1\nLINE2\nLINE3");
+}
+
+/// Test regex with dot_all mode
+#[tokio::test]
+async fn test_regex_edit_dot_all() {
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let file_path = create_temp_file(
+        temp_dir.join("dir1").as_path(),
+        "test.html",
+        "<div>hello\nworld</div>",
+    );
+
+    let edits = vec![EditOperation::Regex {
+        pattern: "<div>(.*?)</div>".to_string(),
+        replacement: "<span>$1</span>".to_string(),
+        options: Some(RegexEditOptions {
+            case_insensitive: None,
+            multiline: None,
+            dot_all: Some(true),
+            max_replacements: None,
+        }),
+    }];
+
+    let result = service
+        .apply_file_edits(&file_path, edits, Some(false), None, None)
+        .await
+        .unwrap();
+
+    let new_content = fs::read_to_string(&file_path).unwrap();
+    assert_eq!(new_content, "<span>hello\nworld</span>");
+}
+
+/// Test mixing exact and regex edits
+#[tokio::test]
+async fn test_mixed_exact_and_regex_edits() {
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let file_path = create_temp_file(
+        temp_dir.join("dir1").as_path(),
+        "test.js",
+        "const version = '1.0.0';\nfunction test() {}",
+    );
+
+    let edits = vec![
+        EditOperation::Exact {
+            old_text: "const version = '1.0.0';".to_string(),
+            new_text: "const version = '2.0.0';".to_string(),
+        },
+        EditOperation::Regex {
+            pattern: r"function\s+(\w+)".to_string(),
+            replacement: "async function $1".to_string(),
+            options: None,
+        },
+    ];
+
+    let result = service
+        .apply_file_edits(&file_path, edits, Some(false), None, None)
+        .await
+        .unwrap();
+
+    let new_content = fs::read_to_string(&file_path).unwrap();
+    assert!(new_content.contains("const version = '2.0.0';"));
+    assert!(new_content.contains("async function test"));
+}
+
+/// Test line range with exact edit
+#[tokio::test]
+async fn test_line_range_exact_edit() {
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let file_path = create_temp_file(
+        temp_dir.join("dir1").as_path(),
+        "test.txt",
+        "line1\nline2\nline3\nline4\nline5",
+    );
+
+    let edits = vec![EditOperation::Exact {
+        old_text: "line3".to_string(),
+        new_text: "LINE3".to_string(),
+    }];
+
+    let result = service
+        .apply_file_edits(&file_path, edits, Some(false), None, Some("2-4".to_string()))
+        .await
+        .unwrap();
+
+    let new_content = fs::read_to_string(&file_path).unwrap();
+    assert_eq!(new_content, "line1\nline2\nLINE3\nline4\nline5");
+}
+
+/// Test line range with regex edit
+#[tokio::test]
+async fn test_line_range_regex_edit() {
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let file_path = create_temp_file(
+        temp_dir.join("dir1").as_path(),
+        "test.txt",
+        "line1\nline2\nline3\nline4\nline5",
+    );
+
+    let edits = vec![EditOperation::Regex {
+        pattern: "line".to_string(),
+        replacement: "LINE".to_string(),
+        options: None,
+    }];
+
+    // Only apply to lines 2-4 (1-based), should affect line2, line3, line4
+    let result = service
+        .apply_file_edits(&file_path, edits, Some(false), None, Some("2-4".to_string()))
+        .await
+        .unwrap();
+
+    let new_content = fs::read_to_string(&file_path).unwrap();
+    assert_eq!(new_content, "line1\nLINE2\nLINE3\nLINE4\nline5");
+}
+
+/// Test invalid regex pattern
+#[tokio::test]
+async fn test_regex_edit_invalid_pattern() {
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let file_path = create_temp_file(
+        temp_dir.join("dir1").as_path(),
+        "test.txt",
+        "hello world",
+    );
+
+    let edits = vec![EditOperation::Regex {
+        pattern: "[invalid(".to_string(),  // Invalid regex
+        replacement: "test".to_string(),
+        options: None,
+    }];
+
+    let result = service
+        .apply_file_edits(&file_path, edits, Some(false), None, None)
+        .await;
+
+    assert!(result.is_err());
+}
+
+/// Test invalid line range
+#[tokio::test]
+async fn test_invalid_line_range() {
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let file_path = create_temp_file(
+        temp_dir.join("dir1").as_path(),
+        "test.txt",
+        "line1\nline2\nline3",
+    );
+
+    let edits = vec![EditOperation::Exact {
+        old_text: "line2".to_string(),
+        new_text: "LINE2".to_string(),
+    }];
+
+    // Invalid format
+    let result = service
+        .apply_file_edits(&file_path, edits.clone(), Some(false), None, Some("invalid".to_string()))
+        .await;
+    assert!(result.is_err());
+
+    // Start >= end
+    let result = service
+        .apply_file_edits(&file_path, edits.clone(), Some(false), None, Some("5-2".to_string()))
+        .await;
+    assert!(result.is_err());
+
+    // Start beyond file
+    let result = service
+        .apply_file_edits(&file_path, edits, Some(false), None, Some("10-20".to_string()))
+        .await;
+    assert!(result.is_err());
+}
+
+/// Test capture groups in replacement
+#[tokio::test]
+async fn test_regex_capture_groups() {
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let file_path = create_temp_file(
+        temp_dir.join("dir1").as_path(),
+        "test.js",
+        "import React from 'react';",
+    );
+
+    let edits = vec![EditOperation::Regex {
+        pattern: r"import\s+(\w+)\s+from\s+'([^']+)'".to_string(),
+        replacement: "import { $1 } from '$2'".to_string(),
+        options: None,
+    }];
+
+    let result = service
+        .apply_file_edits(&file_path, edits, Some(false), None, None)
+        .await
+        .unwrap();
+
+    let new_content = fs::read_to_string(&file_path).unwrap();
+    assert_eq!(new_content, "import { React } from 'react';");
+}


### PR DESCRIPTION
### 📌 Summary
This pull request extends the file editing tool to include regular expression support, providing more flexible and powerful text manipulation capabilities.

### 🔍 Related Issues


- Fixes #


### ✨ Changes Made


- Introduces regex-based edits with options for case sensitivity, multiline matching, and dot-all mode.
- Adds support for limiting the number of replacements in regex edits.
- Enables specifying a line range to restrict edits within a specific portion of the file.
- Introduces new `EditOperation` enum to support `Exact` or `Regex` based replacements.

### 🛠️ Testing Steps


### 💡 Additional Notes