### PR TITLE
fix: normalize Windows drive paths for mounted roots

### DIFF
--- a/src/fs_service/core.rs
+++ b/src/fs_service/core.rs
@@ -72,14 +72,13 @@ impl FileSystemService {
         };
 
         // Normalize the path
-        let normalized_requested = normalize_windows_drive_path(&normalize_path(&absolute_path));
+        let normalized_requested = normalize_path(&absolute_path);
 
         // Check if path is within allowed directories
         if !allowed_directories.iter().any(|dir| {
             // Must account for both scenarios - the requested path may not exist yet, making canonicalization impossible.
-            let normalized_dir = normalize_windows_drive_path(&normalize_path(dir));
             normalized_requested.starts_with(dir)
-                || normalized_requested.starts_with(&normalized_dir)
+                || normalized_requested.starts_with(normalize_path(dir))
         }) {
             let symlink_target = if contains_symlink(&absolute_path)? {
                 "a symlink target path"

--- a/src/fs_service/core.rs
+++ b/src/fs_service/core.rs
@@ -1,6 +1,9 @@
 use crate::{
     error::{ServiceError, ServiceResult},
-    fs_service::utils::{contains_symlink, expand_home, normalize_path, parse_file_path},
+    fs_service::utils::{
+        contains_symlink, expand_home, normalize_path, normalize_windows_drive_path,
+        parse_file_path,
+    },
 };
 use std::{
     collections::HashSet,
@@ -22,7 +25,7 @@ impl FileSystemService {
             .iter()
             .map(fix_dockerhub_mcp_registry_gateway)
             .map(|dir| {
-                let expand_result = expand_home(dir.into());
+                let expand_result = expand_home(normalize_windows_drive_path(Path::new(dir)));
                 if !expand_result.is_dir() {
                     return Err(ServiceError::InvalidConfig(format!(
                         "Error: The path `{dir}` is not a valid directory. Please double-check your server configuration to ensure the directory exists and is accessible."
@@ -59,7 +62,7 @@ impl FileSystemService {
         }
 
         // Expand ~ to home directory
-        let expanded_path = expand_home(requested_path.to_path_buf());
+        let expanded_path = expand_home(normalize_windows_drive_path(requested_path));
 
         // Resolve the absolute path
         let absolute_path = if expanded_path.as_path().is_absolute() {
@@ -69,13 +72,14 @@ impl FileSystemService {
         };
 
         // Normalize the path
-        let normalized_requested = normalize_path(&absolute_path);
+        let normalized_requested = normalize_windows_drive_path(&normalize_path(&absolute_path));
 
         // Check if path is within allowed directories
         if !allowed_directories.iter().any(|dir| {
             // Must account for both scenarios - the requested path may not exist yet, making canonicalization impossible.
+            let normalized_dir = normalize_windows_drive_path(&normalize_path(dir));
             normalized_requested.starts_with(dir)
-                || normalized_requested.starts_with(normalize_path(dir))
+                || normalized_requested.starts_with(&normalized_dir)
         }) {
             let symlink_target = if contains_symlink(&absolute_path)? {
                 "a symlink target path"

--- a/src/fs_service/utils.rs
+++ b/src/fs_service/utils.rs
@@ -75,6 +75,50 @@ pub fn normalize_path(path: &Path) -> PathBuf {
     path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
+pub fn normalize_windows_drive_path(path: &Path) -> PathBuf {
+    let path_text = path.to_string_lossy();
+    let Some((drive, rest)) = split_windows_drive_path(&path_text) else {
+        return path.to_path_buf();
+    };
+
+    windows_drive_path_buf(drive, &rest)
+}
+
+fn split_windows_drive_path(input: &str) -> Option<(char, String)> {
+    let normalized = input.trim().replace('\\', "/");
+    let without_leading_slash = normalized.strip_prefix('/').unwrap_or(&normalized);
+    let bytes = without_leading_slash.as_bytes();
+
+    if bytes.len() < 3 || !bytes[0].is_ascii_alphabetic() || bytes[1] != b':' || bytes[2] != b'/' {
+        return None;
+    }
+
+    Some((
+        (bytes[0] as char).to_ascii_uppercase(),
+        without_leading_slash[3..]
+            .trim_start_matches('/')
+            .to_string(),
+    ))
+}
+
+#[cfg(windows)]
+fn windows_drive_path_buf(drive: char, rest: &str) -> PathBuf {
+    if rest.is_empty() {
+        PathBuf::from(format!("{drive}:/"))
+    } else {
+        PathBuf::from(format!("{drive}:/{rest}"))
+    }
+}
+
+#[cfg(not(windows))]
+fn windows_drive_path_buf(drive: char, rest: &str) -> PathBuf {
+    if rest.is_empty() {
+        PathBuf::from(format!("/{drive}"))
+    } else {
+        PathBuf::from(format!("/{drive}/{rest}"))
+    }
+}
+
 pub fn expand_home(path: PathBuf) -> PathBuf {
     if let Some(home_dir) = home_dir()
         && path.starts_with("~")
@@ -260,7 +304,7 @@ pub async fn validate_file_size<P: AsRef<Path>>(
 
 /// Converts a string to a `PathBuf`, supporting both raw paths and `file://` URIs.
 pub fn parse_file_path(input: &str) -> ServiceResult<PathBuf> {
-    Ok(PathBuf::from(
+    Ok(normalize_windows_drive_path(Path::new(
         input.strip_prefix("file://").unwrap_or(input).trim(),
-    ))
+    )))
 }

--- a/src/fs_service/utils.rs
+++ b/src/fs_service/utils.rs
@@ -112,10 +112,11 @@ fn windows_drive_path_buf(drive: char, rest: &str) -> PathBuf {
 
 #[cfg(not(windows))]
 fn windows_drive_path_buf(drive: char, rest: &str) -> PathBuf {
+    let drive = drive.to_ascii_lowercase();
     if rest.is_empty() {
-        PathBuf::from(format!("/{drive}"))
+        PathBuf::from(format!("/mnt/{drive}"))
     } else {
-        PathBuf::from(format!("/{drive}/{rest}"))
+        PathBuf::from(format!("/mnt/{drive}/{rest}"))
     }
 }
 

--- a/tests/test_fs_service.rs
+++ b/tests/test_fs_service.rs
@@ -72,22 +72,27 @@ async fn test_validate_path_denied() {
     assert!(matches!(result, Err(ServiceError::FromString(_))));
 }
 
-#[cfg(not(windows))]
 #[test]
 fn test_normalize_windows_drive_path_for_mounted_roots() {
+    #[cfg(windows)]
+    let expected_project = PathBuf::from("C:/Users/Peter/IdeaProjects");
+    #[cfg(not(windows))]
+    let expected_project = PathBuf::from("/mnt/c/Users/Peter/IdeaProjects");
+    let expected_source = expected_project.join("WashlyServer/src/main.rs");
+
     assert_eq!(
         normalize_windows_drive_path(Path::new(
             r"C:\Users\Peter\IdeaProjects\WashlyServer\src\main.rs"
         )),
-        PathBuf::from("/C/Users/Peter/IdeaProjects/WashlyServer/src/main.rs")
+        expected_source
     );
     assert_eq!(
         normalize_windows_drive_path(Path::new(r"/c:\Users\Peter\IdeaProjects")),
-        PathBuf::from("/C/Users/Peter/IdeaProjects")
+        expected_project
     );
     assert_eq!(
         parse_file_path("file:///C:/Users/Peter/IdeaProjects").unwrap(),
-        PathBuf::from("/C/Users/Peter/IdeaProjects")
+        expected_project
     );
 }
 
@@ -95,7 +100,7 @@ fn test_normalize_windows_drive_path_for_mounted_roots() {
 #[tokio::test]
 async fn test_validate_path_accepts_native_windows_path_inside_mounted_root() {
     let service = FileSystemService::try_new(&["/".to_string()]).unwrap();
-    let allowed_dirs = std::sync::Arc::new(vec![PathBuf::from("/C/Users/Peter/IdeaProjects")]);
+    let allowed_dirs = std::sync::Arc::new(vec![PathBuf::from("/mnt/c/Users/Peter/IdeaProjects")]);
 
     let result = service.validate_path(
         Path::new(r"C:\Users\Peter\IdeaProjects\WashlyServer\src\main.rs"),
@@ -104,7 +109,7 @@ async fn test_validate_path_accepts_native_windows_path_inside_mounted_root() {
 
     assert_eq!(
         result.unwrap(),
-        PathBuf::from("/C/Users/Peter/IdeaProjects/WashlyServer/src/main.rs")
+        PathBuf::from("/mnt/c/Users/Peter/IdeaProjects/WashlyServer/src/main.rs")
     );
 }
 
@@ -112,7 +117,7 @@ async fn test_validate_path_accepts_native_windows_path_inside_mounted_root() {
 #[tokio::test]
 async fn test_validate_path_rejects_native_windows_path_outside_mounted_root() {
     let service = FileSystemService::try_new(&["/".to_string()]).unwrap();
-    let allowed_dirs = std::sync::Arc::new(vec![PathBuf::from("/C/Users/Peter/IdeaProjects")]);
+    let allowed_dirs = std::sync::Arc::new(vec![PathBuf::from("/mnt/c/Users/Peter/IdeaProjects")]);
 
     let result = service.validate_path(
         Path::new(r"C:\Users\Peter\Downloads\outside.txt"),

--- a/tests/test_fs_service.rs
+++ b/tests/test_fs_service.rs
@@ -72,6 +72,56 @@ async fn test_validate_path_denied() {
     assert!(matches!(result, Err(ServiceError::FromString(_))));
 }
 
+#[cfg(not(windows))]
+#[test]
+fn test_normalize_windows_drive_path_for_mounted_roots() {
+    assert_eq!(
+        normalize_windows_drive_path(Path::new(
+            r"C:\Users\Peter\IdeaProjects\WashlyServer\src\main.rs"
+        )),
+        PathBuf::from("/C/Users/Peter/IdeaProjects/WashlyServer/src/main.rs")
+    );
+    assert_eq!(
+        normalize_windows_drive_path(Path::new(r"/c:\Users\Peter\IdeaProjects")),
+        PathBuf::from("/C/Users/Peter/IdeaProjects")
+    );
+    assert_eq!(
+        parse_file_path("file:///C:/Users/Peter/IdeaProjects").unwrap(),
+        PathBuf::from("/C/Users/Peter/IdeaProjects")
+    );
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn test_validate_path_accepts_native_windows_path_inside_mounted_root() {
+    let service = FileSystemService::try_new(&["/".to_string()]).unwrap();
+    let allowed_dirs = std::sync::Arc::new(vec![PathBuf::from("/C/Users/Peter/IdeaProjects")]);
+
+    let result = service.validate_path(
+        Path::new(r"C:\Users\Peter\IdeaProjects\WashlyServer\src\main.rs"),
+        allowed_dirs,
+    );
+
+    assert_eq!(
+        result.unwrap(),
+        PathBuf::from("/C/Users/Peter/IdeaProjects/WashlyServer/src/main.rs")
+    );
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn test_validate_path_rejects_native_windows_path_outside_mounted_root() {
+    let service = FileSystemService::try_new(&["/".to_string()]).unwrap();
+    let allowed_dirs = std::sync::Arc::new(vec![PathBuf::from("/C/Users/Peter/IdeaProjects")]);
+
+    let result = service.validate_path(
+        Path::new(r"C:\Users\Peter\Downloads\outside.txt"),
+        allowed_dirs,
+    );
+
+    assert!(matches!(result, Err(ServiceError::FromString(_))));
+}
+
 #[test]
 fn test_normalize_line_endings() {
     let input = "line1\r\nline2\r\nline3";


### PR DESCRIPTION
Closes #87

Summary:
- Normalize Windows drive-letter paths before allowed-directory validation, so `C:\...` and `C:/...` match mounted roots such as `/C/...` when the server runs in a Unix-style environment.
- Apply the same normalization to configured allowed directories and `file://` roots.
- Add regression coverage for native Windows paths inside mounted roots and rejection outside the allowed root.

Validation:
- `cargo fmt --all -- --check`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo check --tests --target x86_64-unknown-linux-gnu`