### PR TITLE
fix: prevent path-traversal sandbox escape in filesystem operations

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+## Reporting a Vulnerability
+
+Please report security vulnerabilities via GitHub Security Advisories at
+https://github.com/rust-mcp-stack/rust-mcp-filesystem/security/advisories/new.
+
+We aim to respond within 48 hours.

--- a/src/fs_service/core.rs
+++ b/src/fs_service/core.rs
@@ -8,7 +8,7 @@ use crate::{
 use std::{
     collections::HashSet,
     env,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     sync::Arc,
 };
 use tokio::sync::RwLock;
@@ -74,6 +74,16 @@ impl FileSystemService {
         // Normalize the path
         let normalized_requested = normalize_path(&absolute_path);
 
+        // Defence-in-depth: reject paths with unresolved parent directory components
+        if normalized_requested
+            .components()
+            .any(|c| c == Component::ParentDir)
+        {
+            return Err(ServiceError::FromString(
+                "Path contains unresolved parent directory components".into(),
+            ));
+        }
+
         // Check if path is within allowed directories
         if !allowed_directories.iter().any(|dir| {
             // Must account for both scenarios - the requested path may not exist yet, making canonicalization impossible.
@@ -97,7 +107,7 @@ impl FileSystemService {
             )));
         }
 
-        Ok(absolute_path)
+        Ok(normalized_requested)
     }
 
     pub fn valid_roots(&self, roots: Vec<&str>) -> ServiceResult<(Vec<PathBuf>, Option<String>)> {

--- a/src/fs_service/io/edit.rs
+++ b/src/fs_service/io/edit.rs
@@ -47,7 +47,7 @@ impl FileSystemService {
         replace_all: Option<bool>,
     ) -> ServiceResult<String> {
         let allowed_directories = self.allowed_directories().await;
-        let valid_path = self.validate_path(file_path, allowed_directories)?;
+        let valid_path = self.validate_path(file_path, allowed_directories.clone())?;
 
         // Read file content and normalize line endings
         let content_str = tokio::fs::read_to_string(&valid_path).await?;
@@ -293,7 +293,11 @@ impl FileSystemService {
         let is_dry_run = dry_run.unwrap_or(false);
 
         if !is_dry_run {
-            let target = save_to.unwrap_or(valid_path.as_path());
+            let target = if let Some(save_to_path) = save_to {
+                self.validate_path(save_to_path, allowed_directories)?
+            } else {
+                valid_path.as_path().to_path_buf()
+            };
             let modified_content = modified_content.replace("\n", original_line_ending);
             tokio::fs::write(target, modified_content).await?;
         }

--- a/src/fs_service/utils.rs
+++ b/src/fs_service/utils.rs
@@ -72,7 +72,16 @@ pub fn format_permissions(metadata: &fs::Metadata) -> String {
 }
 
 pub fn normalize_path(path: &Path) -> PathBuf {
-    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    if let Ok(canonical) = path.canonicalize() {
+        return canonical;
+    }
+    if let Some(parent) = path.parent()
+        && let Ok(canonical_parent) = parent.canonicalize()
+        && let Some(file_name) = path.file_name()
+    {
+        return canonical_parent.join(file_name);
+    }
+    path.to_path_buf()
 }
 
 pub fn normalize_windows_drive_path(path: &Path) -> PathBuf {

--- a/tests/test_fs_service.rs
+++ b/tests/test_fs_service.rs
@@ -72,6 +72,155 @@ async fn test_validate_path_denied() {
     assert!(matches!(result, Err(ServiceError::FromString(_))));
 }
 
+#[tokio::test]
+async fn test_path_traversal_rejected() {
+    // CVE-style PoC: ../.. escape from inside the allowed root must be denied.
+    let (temp_dir, service, allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let traversal = temp_dir
+        .join("dir1")
+        .join("..")
+        .join("..")
+        .join("dir2")
+        .join("pwned.txt");
+    let result = service.validate_path(&traversal, allowed_dirs);
+    assert!(matches!(result, Err(ServiceError::FromString(_))));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_path_traversal_with_symlink_rejected() {
+    // Symlink in the allowed root pointing outside must be rejected for writes.
+    let (temp_dir, service, allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let outside = temp_dir.join("dir2");
+    std::fs::create_dir(&outside).unwrap();
+    let symlink_path = temp_dir.join("dir1").join("link");
+    std::os::unix::fs::symlink(&outside, &symlink_path).unwrap();
+    let result = service.validate_path(&symlink_path.join("target.txt"), allowed_dirs);
+    assert!(matches!(result, Err(ServiceError::FromString(_))));
+}
+
+#[tokio::test]
+async fn test_path_traversal_via_write_file_rejected() {
+    // End-to-end: write_file with .. path must not escape the sandbox.
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let traversal_path = temp_dir
+        .join("dir1")
+        .join("..")
+        .join("dir2")
+        .join("pwned.txt");
+    let result = service
+        .write_file(&traversal_path, &"PWNED".to_string())
+        .await;
+    assert!(result.is_err());
+    assert!(!traversal_path.exists());
+    assert!(!temp_dir.join("dir2").join("pwned.txt").exists());
+}
+
+#[tokio::test]
+async fn test_path_traversal_via_create_directory_rejected() {
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let traversal_path = temp_dir
+        .join("dir1")
+        .join("..")
+        .join("dir2")
+        .join("escape_dir");
+    let result = service.create_directory(&traversal_path).await;
+    assert!(result.is_err());
+    assert!(!traversal_path.exists());
+}
+
+#[tokio::test]
+async fn test_path_traversal_via_move_file_rejected() {
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let src = create_temp_file(&temp_dir.join("dir1"), "src.txt", "content");
+    let dest = temp_dir
+        .join("dir1")
+        .join("..")
+        .join("dir2")
+        .join("moved.txt");
+    let result = service.move_file(&src, &dest).await;
+    assert!(result.is_err());
+    assert!(src.exists());
+    assert!(!dest.exists());
+}
+
+#[tokio::test]
+async fn test_path_traversal_via_edit_save_to_rejected() {
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let src = create_temp_file(&temp_dir.join("dir1"), "src.txt", "foo = 1\n");
+    let save_to = temp_dir
+        .join("dir1")
+        .join("..")
+        .join("dir2")
+        .join("escape.txt");
+    let edits = vec![EditOperation {
+        old_text: "foo = 1\n".into(),
+        new_text: "foo = 2\n".into(),
+    }];
+    let result = service
+        .apply_file_edits(&src, edits, Some(false), Some(&save_to), None)
+        .await;
+    assert!(result.is_err());
+    assert!(!save_to.exists());
+}
+
+#[tokio::test]
+async fn test_path_traversal_multiple_parent_dirs_rejected() {
+    let (temp_dir, service, allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let traversal = temp_dir
+        .join("dir1")
+        .join("..")
+        .join("..")
+        .join("..")
+        .join("..")
+        .join("etc")
+        .join("passwd");
+    let result = service.validate_path(&traversal, allowed_dirs);
+    assert!(matches!(result, Err(ServiceError::FromString(_))));
+}
+
+#[tokio::test]
+async fn test_path_traversal_existing_parent_resolves_correctly() {
+    // Path with .. that canonicalizes to inside the allowed root should still work.
+    let (temp_dir, service, allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let sub_dir = temp_dir.join("dir1").join("subdir");
+    std::fs::create_dir(&sub_dir).unwrap();
+    let file_path = sub_dir.join("..").join("subdir").join("test.txt");
+    create_temp_file(&sub_dir, "test.txt", "content");
+    let result = service.validate_path(&file_path, allowed_dirs);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), sub_dir.join("test.txt"));
+}
+
+#[tokio::test]
+async fn test_path_traversal_nonexistent_with_existing_parent_rejected() {
+    // Non-existent write target whose parent resolves outside the allowed root.
+    let (temp_dir, service, allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let traversal = temp_dir
+        .join("dir1")
+        .join("..")
+        .join("..")
+        .join("dir2")
+        .join("pwned.txt");
+    let result = service.validate_path(&traversal, allowed_dirs);
+    assert!(matches!(result, Err(ServiceError::FromString(_))));
+}
+
+#[tokio::test]
+async fn test_path_traversal_defence_in_depth_parent_dir() {
+    // Defense-in-depth: even if normalization somehow leaves .., reject it.
+    let (temp_dir, service, allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let traversal = temp_dir
+        .join("dir1")
+        .join("..")
+        .join("dir2")
+        .join("pwned.txt");
+    let result = service.validate_path(&traversal, allowed_dirs);
+    assert!(matches!(result, Err(ServiceError::FromString(_))));
+    // And the path itself should not have been created
+    assert!(!traversal.exists());
+}
+
 #[test]
 fn test_normalize_windows_drive_path_for_mounted_roots() {
     #[cfg(windows)]


### PR DESCRIPTION
### 📌 Summary
Fix path-traversal sandbox escape in filesystem operations. The `normalize_path` function fell back to raw (unsanitized) paths when `canonicalize()` failed for non-existent files, allowing `..` components to bypass `validate_path`. This enables escaping the allowed directory sandbox via `write_file`, `create_directory`, `move_file`, and `edit` save-to.

### 🔍 Related Issues
<!-- No existing issue references -->

### ✨ Changes Made
- `normalize_path` now attempts to canonicalize the parent directory and rejoin the file name when the full path doesn't exist. Falls back to raw path only as last resort.
- `validate_path` returns the *normalized* path instead of the raw `absolute_path`. Added defense-in-depth rejection of any path still containing `Component::ParentDir` after normalization.
- `save_to` now passes through `validate_path` with the allowed directories set (previously skipped validation entirely).
- Added 10 regression tests covering `..` escape, symlink escape (unix), write/create/move/edit end-to-end escapes, multi-level `..`, resolved-in-root paths, non-existent-with-out-of-bounds-parent, and defense-in-depth.

### 🛠️ Testing Steps
```
cargo make check
```

### 💡 Additional Notes
- A GitHub Security Advisory (with CVE request) has been drafted and will be published simultaneously with the release containing this fix.
- `SECURITY.md` added to document the vulnerability reporting process.
- CVE ID to be added to `CHANGELOG.md` at release time.