### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # Rust MCP Filesystem
 
+[![MCP Toplist](https://mcptoplist.com/badge/glama%2Frust-mcp-stack%2Frust-mcp-filesystem.svg)](https://mcptoplist.com/server/glama%2Frust-mcp-stack%2Frust-mcp-filesystem)
+
 Rust MCP Filesystem is a blazingly fast, asynchronous, and lightweight MCP (Model Context Protocol) server designed for efficient handling of various filesystem operations.
 This project is a pure Rust rewrite of the JavaScript-based `@modelcontextprotocol/server-filesystem`, offering enhanced capabilities, improved performance, and a robust feature set tailored for modern filesystem interactions.
 


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 94,094 MCP servers across the major
registries, and **Rust MCP Filesystem** is currently ranked **#1,812**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/glama%2Frust-mcp-stack%2Frust-mcp-filesystem.svg)](https://mcptoplist.com/server/glama%2Frust-mcp-stack%2Frust-mcp-filesystem)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building Rust MCP Filesystem!
