### PR TITLE
fix: prevent symlink path-traversal escape via cap-std sandboxing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,7 +68,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -73,7 +79,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -151,6 +157,36 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ec78e242cfa2cfe276807ac2ecc00315a6c97786977414bcd1c3963b6c91b8"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix",
+]
 
 [[package]]
 name = "cc"
@@ -409,7 +445,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -460,7 +496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -490,6 +526,17 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "futures"
@@ -771,6 +818,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
+name = "ipnet"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +915,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,7 +953,7 @@ checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1137,6 +1218,7 @@ version = "0.4.3"
 dependencies = [
  "async-trait",
  "base64",
+ "cap-std",
  "chrono",
  "clap",
  "dirs",
@@ -1156,7 +1238,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
- "walkdir",
  "zip",
 ]
 
@@ -1233,7 +1314,17 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -1241,15 +1332,6 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "scopeguard"
@@ -1364,7 +1446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1405,7 +1487,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1483,7 +1565,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1588,16 +1670,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,7 +1742,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1740,6 +1812,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1748,12 +1838,151 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
 name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rust-mcp-sdk = {version="1.0", default-features = false, features = [
 
 thiserror = { version = "2.0" }
 dirs = "6.0"
-walkdir = "2.5"
+cap-std = "4"
 similar = "=2.7"
 chrono = "0.4"
 clap = { version = "4.5", features = ["derive","env"] }

--- a/src/fs_service.rs
+++ b/src/fs_service.rs
@@ -4,6 +4,6 @@ mod io;
 mod search;
 pub mod utils;
 
-pub use core::FileSystemService;
+pub use core::{FileSystemService, FsEntry, Resolved, walk_dir};
 pub use io::FileInfo;
 pub use search::FileSearchResult;

--- a/src/fs_service/archive/unzip.rs
+++ b/src/fs_service/archive/unzip.rs
@@ -1,16 +1,15 @@
 use crate::{error::ServiceResult, fs_service::FileSystemService};
 use rc_zip_tokio::ReadZip;
-use std::path::Path;
-use tokio::fs::File;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tokio::io::AsyncReadExt;
 
 impl FileSystemService {
     pub async fn unzip_file(&self, zip_file: &str, target_dir: &str) -> ServiceResult<String> {
-        let allowed_directories = self.allowed_directories().await;
+        let resolved_zip = self.resolve(Path::new(zip_file)).await?;
+        let resolved_target = self.resolve(Path::new(target_dir)).await?;
 
-        let zip_file = self.validate_path(Path::new(&zip_file), allowed_directories.clone())?;
-        let target_dir_path = self.validate_path(Path::new(target_dir), allowed_directories)?;
-        if !zip_file.exists() {
+        if !resolved_zip.dir.exists(&resolved_zip.rel) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
                 "Zip file does not exists.",
@@ -18,7 +17,7 @@ impl FileSystemService {
             .into());
         }
 
-        if target_dir_path.exists() {
+        if resolved_target.dir.exists(&resolved_target.rel) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::AlreadyExists,
                 format!("'{target_dir}' directory already exists!"),
@@ -26,9 +25,7 @@ impl FileSystemService {
             .into());
         }
 
-        let mut file = File::open(&zip_file).await?;
-        let mut zip_data = Vec::new();
-        file.read_to_end(&mut zip_data).await?;
+        let zip_data = resolved_zip.dir.read(&resolved_zip.rel)?;
 
         let archive = zip_data.read_zip().await?;
 
@@ -39,25 +36,25 @@ impl FileSystemService {
             let name = entry.sanitized_name().ok_or_else(|| {
                 std::io::Error::new(std::io::ErrorKind::InvalidData, "Invalid entry name")
             })?;
-            let entry_path = target_dir_path.join(name);
-            if let Some(parent) = entry_path.parent() {
-                tokio::fs::create_dir_all(parent).await?;
+            let entry_rel = resolved_target.rel.join(PathBuf::from(name));
+            if let Some(parent) = entry_rel.parent() {
+                resolved_target.dir.create_dir_all(parent)?;
             }
 
             let mut reader = entry.reader();
-            let mut output_file = File::create(&entry_path).await?;
+            let mut output_file = resolved_target.dir.create(&entry_rel)?;
 
             let mut buffer = Vec::new();
             reader.read_to_end(&mut buffer).await?;
-            output_file.write_all(&buffer).await?;
-            output_file.flush().await?;
+            output_file.write_all(&buffer)?;
+            output_file.flush()?;
         }
 
         let result_message = format!(
             "Successfully extracted {} {} into '{}'.",
             file_count,
             if file_count == 1 { "file" } else { "files" },
-            target_dir_path.display()
+            resolved_target.display.display()
         );
 
         Ok(result_message)

--- a/src/fs_service/archive/zip.rs
+++ b/src/fs_service/archive/zip.rs
@@ -1,9 +1,11 @@
-use crate::{error::ServiceResult, fs_service::FileSystemService};
+use crate::{
+    error::ServiceResult,
+    fs_service::{FileSystemService, walk_dir},
+};
+use cap_std::fs::Dir;
 use glob_match::glob_match;
-use std::fs::File as StdFile;
-use std::io::Write;
-use std::path::Path;
-use walkdir::WalkDir;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 use zip::CompressionMethod;
 use zip::write::ZipWriter;
 
@@ -30,22 +32,10 @@ impl FileSystemService {
         pattern: String,
         target_zip_file: String,
     ) -> ServiceResult<String> {
-        let allowed_directories = self.allowed_directories().await;
-        let valid_dir_path =
-            self.validate_path(Path::new(&input_dir), allowed_directories.clone())?;
+        let resolved_input = self.resolve(Path::new(&input_dir)).await?;
+        let resolved_target = self.resolve(Path::new(&target_zip_file)).await?;
 
-        let input_dir_str = &valid_dir_path
-            .as_os_str()
-            .to_str()
-            .ok_or(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "Invalid UTF-8 in file name",
-            ))?;
-
-        let target_path =
-            self.validate_path(Path::new(&target_zip_file), allowed_directories.clone())?;
-
-        if target_path.exists() {
+        if resolved_target.dir.exists(&resolved_target.rel) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::AlreadyExists,
                 format!("'{target_zip_file}' already exists!"),
@@ -58,68 +48,56 @@ impl FileSystemService {
         } else {
             format!("*{}*", &pattern.to_lowercase())
         };
+        let glob_pattern = updated_pattern;
 
-        let glob_pattern = &updated_pattern;
+        // Confined recursive traversal.
+        let mut all_entries = Vec::new();
+        walk_dir(
+            &resolved_input.dir,
+            &resolved_input.rel,
+            &resolved_input.display,
+            &mut all_entries,
+        )?;
 
-        let entries: Vec<_> = WalkDir::new(&valid_dir_path)
-            .follow_links(true)
-            .into_iter()
-            .filter_map(|entry| entry.ok())
-            .filter_map(|entry| {
-                let full_path = entry.path();
+        let mut entries: Vec<PathBuf> = Vec::new();
+        for entry in all_entries {
+            if entry.is_dir {
+                continue;
+            }
+            let rel_from_input = entry
+                .rel
+                .strip_prefix(&resolved_input.rel)
+                .unwrap_or(&entry.rel);
+            if glob_match(&glob_pattern, rel_from_input.to_str().unwrap_or("")) {
+                entries.push(entry.rel);
+            }
+        }
 
-                self.validate_path(full_path, allowed_directories.clone())
-                    .ok()
-                    .and_then(|path| {
-                        if path != valid_dir_path {
-                            let relative_path = path
-                                .strip_prefix(input_dir_str)
-                                .ok()
-                                .map(|p| p.display().to_string());
-                            let matches = relative_path
-                                .map(|rel| glob_match(glob_pattern, rel.as_ref()))
-                                .unwrap_or(false);
-                            if matches {
-                                return Some(path);
-                            }
-                        }
-                        None
-                    })
-            })
-            .collect();
-
-        let target_path_clone = target_path.clone();
-        let entries_clone: Vec<_> = entries.to_vec();
-        let input_dir_str_clone = input_dir_str.to_string();
+        let dir = resolved_input.dir.try_clone()?;
+        let input_rel = resolved_input.rel.clone();
+        let target_dir = resolved_target.dir.try_clone()?;
+        let target_rel = resolved_target.rel.clone();
 
         let zip_file_size = tokio::task::spawn_blocking(move || {
-            let file = StdFile::create(&target_path_clone)?;
+            let file = target_dir.create(&target_rel)?;
             let mut zip_writer = ZipWriter::new(file);
             let options: zip::write::FileOptions<()> =
                 zip::write::FileOptions::default().compression_method(CompressionMethod::Deflated);
 
-            for entry_path_buf in &entries_clone {
-                if entry_path_buf.is_dir() {
-                    continue;
-                }
-                let entry_path = entry_path_buf.as_path();
-                let entry_str = entry_path.as_os_str().to_str().ok_or(std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "Invalid UTF-8 in file name",
-                ))?;
-
-                if !entry_str.starts_with(&input_dir_str_clone) {
-                    return Err(std::io::Error::new(
+            for entry_rel in &entries {
+                let rel_from_input = entry_rel
+                    .strip_prefix(&input_rel)
+                    .map_err(std::io::Error::other)?;
+                let entry_str = rel_from_input
+                    .to_str()
+                    .ok_or_else(|| std::io::Error::new(
                         std::io::ErrorKind::InvalidInput,
-                        "Entry file path does not start with base input directory path.",
-                    ));
-                }
+                        "Invalid UTF-8 in file name",
+                    ))?;
 
-                let entry_str = &entry_str[input_dir_str_clone.len() + 1..];
-
-                let mut input_file = StdFile::open(entry_path)?;
+                let mut input_file = dir.open(entry_rel)?;
                 let mut buffer = Vec::new();
-                std::io::Read::read_to_end(&mut input_file, &mut buffer)?;
+                input_file.read_to_end(&mut buffer)?;
 
                 zip_writer.start_file(entry_str, options)?;
                 zip_writer.write_all(&buffer)?;
@@ -127,7 +105,7 @@ impl FileSystemService {
             }
 
             zip_writer.finish()?;
-            let metadata = std::fs::metadata(&target_path_clone)?;
+            let metadata = target_dir.metadata(&target_rel)?;
             Ok::<u64, std::io::Error>(metadata.len())
         })
         .await
@@ -136,7 +114,7 @@ impl FileSystemService {
         let result_message = format!(
             "Successfully compressed '{}' directory into '{}' ({}).",
             input_dir,
-            target_path.display(),
+            resolved_target.display.display(),
             format_bytes_size(zip_file_size)
         );
         Ok(result_message)
@@ -156,11 +134,10 @@ impl FileSystemService {
             )
             .into());
         }
-        let allowed_directories = self.allowed_directories().await;
-        let target_path =
-            self.validate_path(Path::new(&target_zip_file), allowed_directories.clone())?;
 
-        if target_path.exists() {
+        let resolved_target = self.resolve(Path::new(&target_zip_file)).await?;
+
+        if resolved_target.dir.exists(&resolved_target.rel) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::AlreadyExists,
                 format!("'{target_zip_file}' already exists!"),
@@ -168,34 +145,39 @@ impl FileSystemService {
             .into());
         }
 
-        let source_paths = input_files
-            .iter()
-            .map(|p| self.validate_path(Path::new(p), allowed_directories.clone()))
-            .collect::<Result<Vec<_>, _>>()?;
+        let mut sources: Vec<(Dir, PathBuf, String)> = Vec::with_capacity(file_count);
+        for path in &input_files {
+            let resolved = self.resolve(Path::new(path)).await?;
+            let filename = resolved
+                .rel
+                .file_name()
+                .ok_or_else(|| {
+                    std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid path!")
+                })?
+                .to_str()
+                .ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "Invalid UTF-8 in file name",
+                    )
+                })?
+                .to_string();
+            sources.push((resolved.dir, resolved.rel, filename));
+        }
 
-        let target_path_clone = target_path.clone();
-        let source_paths_clone: Vec<_> = source_paths.to_vec();
+        let target_dir = resolved_target.dir.try_clone()?;
+        let target_rel = resolved_target.rel.clone();
 
         let zip_file_size = tokio::task::spawn_blocking(move || {
-            let file = StdFile::create(&target_path_clone)?;
+            let file = target_dir.create(&target_rel)?;
             let mut zip_writer = ZipWriter::new(file);
             let options: zip::write::FileOptions<()> =
                 zip::write::FileOptions::default().compression_method(CompressionMethod::Deflated);
 
-            for path in &source_paths_clone {
-                let filename = path.file_name().ok_or(std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "Invalid path!",
-                ))?;
-
-                let filename = filename.to_str().ok_or(std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "Invalid UTF-8 in file name",
-                ))?;
-
-                let mut input_file = StdFile::open(path)?;
+            for (dir, rel, filename) in &sources {
+                let mut input_file = dir.open(rel)?;
                 let mut buffer = Vec::new();
-                std::io::Read::read_to_end(&mut input_file, &mut buffer)?;
+                input_file.read_to_end(&mut buffer)?;
 
                 zip_writer.start_file(filename, options)?;
                 zip_writer.write_all(&buffer)?;
@@ -203,7 +185,7 @@ impl FileSystemService {
             }
 
             zip_writer.finish()?;
-            let metadata = std::fs::metadata(&target_path_clone)?;
+            let metadata = target_dir.metadata(&target_rel)?;
             Ok::<u64, std::io::Error>(metadata.len())
         })
         .await
@@ -213,7 +195,7 @@ impl FileSystemService {
             "Successfully compressed {} {} into '{}' ({}).",
             file_count,
             if file_count == 1 { "file" } else { "files" },
-            target_path.display(),
+            resolved_target.display.display(),
             format_bytes_size(zip_file_size)
         );
         Ok(result_message)

--- a/src/fs_service/archive/zip.rs
+++ b/src/fs_service/archive/zip.rs
@@ -88,12 +88,12 @@ impl FileSystemService {
                 let rel_from_input = entry_rel
                     .strip_prefix(&input_rel)
                     .map_err(std::io::Error::other)?;
-                let entry_str = rel_from_input
-                    .to_str()
-                    .ok_or_else(|| std::io::Error::new(
+                let entry_str = rel_from_input.to_str().ok_or_else(|| {
+                    std::io::Error::new(
                         std::io::ErrorKind::InvalidInput,
                         "Invalid UTF-8 in file name",
-                    ))?;
+                    )
+                })?;
 
                 let mut input_file = dir.open(entry_rel)?;
                 let mut buffer = Vec::new();

--- a/src/fs_service/core.rs
+++ b/src/fs_service/core.rs
@@ -1,13 +1,12 @@
 use crate::{
     error::{ServiceError, ServiceResult},
-    fs_service::utils::{
-        contains_symlink, expand_home, normalize_path, normalize_windows_drive_path,
-        parse_file_path,
-    },
+    fs_service::utils::{expand_home, normalize_windows_drive_path, parse_file_path},
 };
+use cap_std::{ambient_authority, fs::Dir};
 use std::{
     collections::HashSet,
     env,
+    io,
     path::{Component, Path, PathBuf},
     sync::Arc,
 };
@@ -15,13 +14,121 @@ use tokio::sync::RwLock;
 
 type PathResultList = Vec<Result<PathBuf, ServiceError>>;
 
+/// A confined, capability-based handle to one of the allowed directories.
+///
+/// All filesystem access is performed relative to [`AllowedDir::dir`], so that
+/// symlink escapes (existing, dangling, or raced) are rejected by the OS layer
+/// rather than by path arithmetic.
+pub struct AllowedDir {
+    /// Canonical absolute path, used only for prefix matching and display.
+    pub path: PathBuf,
+    /// The `cap-std` directory handle that confines access to this subtree.
+    pub dir: Dir,
+}
+
+/// The result of resolving a requested path against the allowed directories.
+///
+/// Carries the confined directory handle and the relative path to operate on.
+pub struct Resolved {
+    pub dir: Dir,
+    pub rel: PathBuf,
+    /// Canonical absolute path, used for display and error messages only.
+    pub display: PathBuf,
+}
+
+/// A filesystem entry discovered during a confined directory traversal.
+pub struct FsEntry {
+    pub dir: Dir,
+    pub rel: PathBuf,
+    pub display: PathBuf,
+    pub file_name: String,
+    pub is_dir: bool,
+    pub len: u64,
+}
+
+impl FsEntry {
+    /// The absolute (display) path of this entry.
+    pub fn path(&self) -> &Path {
+        &self.display
+    }
+
+    /// The file name of this entry.
+    pub fn file_name(&self) -> &str {
+        &self.file_name
+    }
+
+    pub fn is_dir(&self) -> bool {
+        self.is_dir
+    }
+
+    pub fn is_file(&self) -> bool {
+        !self.is_dir
+    }
+
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self) -> u64 {
+        self.len
+    }
+
+    /// Opens this entry for reading through its confined directory handle.
+    pub fn open(&self) -> io::Result<cap_std::fs::File> {
+        self.dir.open(&self.rel)
+    }
+}
+
+/// Recursively collects all entries (files and directories) under `dir`/`base`
+/// into `entries`, confined to `dir`'s subtree. Symlinks are followed only when
+/// they resolve within the subtree; escaping symlinks are skipped.
+pub fn walk_dir(
+    dir: &Dir,
+    base: &Path,
+    display_base: &Path,
+    entries: &mut Vec<FsEntry>,
+) -> io::Result<()> {
+    let read_dir = if base.as_os_str().is_empty() {
+        dir.entries()?
+    } else {
+        dir.read_dir(base)?
+    };
+    for entry in read_dir {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_string = name.to_string_lossy().into_owned();
+
+        let rel = if base.as_os_str().is_empty() {
+            PathBuf::from(&name)
+        } else {
+            base.join(&name)
+        };
+
+        // Follow symlinks (confined) to determine type and length.
+        let meta = dir.metadata(&rel).ok();
+        let is_dir = meta.as_ref().is_some_and(|m| m.is_dir());
+        let len = meta.as_ref().map_or(0, |m| m.len());
+
+        entries.push(FsEntry {
+            dir: dir.try_clone()?,
+            rel: rel.clone(),
+            display: display_base.join(&name),
+            file_name: name_string,
+            is_dir,
+            len,
+        });
+
+        if is_dir {
+            walk_dir(dir, &rel, &display_base.join(&name), entries)?;
+        }
+    }
+    Ok(())
+}
+
 pub struct FileSystemService {
-    allowed_path: RwLock<Arc<Vec<PathBuf>>>,
+    allowed_dirs: RwLock<Arc<Vec<AllowedDir>>>,
 }
 
 impl FileSystemService {
     pub fn try_new(allowed_directories: &[String]) -> ServiceResult<Self> {
-        let normalized_dirs: ServiceResult<Vec<PathBuf>> = allowed_directories
+        let normalized_dirs: ServiceResult<Vec<AllowedDir>> = allowed_directories
             .iter()
             .map(fix_dockerhub_mcp_registry_gateway)
             .map(|dir| {
@@ -31,33 +138,54 @@ impl FileSystemService {
                         "Error: The path `{dir}` is not a valid directory. Please double-check your server configuration to ensure the directory exists and is accessible."
                     )));
                 }
-                Ok(expand_result)
+                let canonical = expand_result.canonicalize().map_err(ServiceError::from)?;
+                let dir = Dir::open_ambient_dir(&canonical, ambient_authority())
+                    .map_err(ServiceError::from)?;
+                Ok(AllowedDir {
+                    path: canonical,
+                    dir,
+                })
             })
             .collect();
 
         Ok(Self {
-            allowed_path: RwLock::new(Arc::new(normalized_dirs?)),
+            allowed_dirs: RwLock::new(Arc::new(normalized_dirs?)),
         })
     }
 
     pub async fn allowed_directories(&self) -> Arc<Vec<PathBuf>> {
-        let guard = self.allowed_path.read().await;
-        guard.clone()
+        let guard = self.allowed_dirs.read().await;
+        Arc::new(guard.iter().map(|ad| ad.path.clone()).collect())
     }
 
     pub async fn update_allowed_paths(&self, valid_roots: Vec<PathBuf>) {
-        let mut guard = self.allowed_path.write().await;
-        *guard = Arc::new(valid_roots)
+        let allowed_dirs: Vec<AllowedDir> = valid_roots
+            .into_iter()
+            .filter_map(|root| {
+                let canonical = root.canonicalize().ok()?;
+                let dir = Dir::open_ambient_dir(&canonical, ambient_authority()).ok()?;
+                Some(AllowedDir {
+                    path: canonical,
+                    dir,
+                })
+            })
+            .collect();
+
+        let mut guard = self.allowed_dirs.write().await;
+        *guard = Arc::new(allowed_dirs);
     }
 
-    pub fn validate_path(
-        &self,
-        requested_path: &Path,
-        allowed_directories: Arc<Vec<PathBuf>>,
-    ) -> ServiceResult<PathBuf> {
-        if allowed_directories.is_empty() {
+    /// Resolves `requested_path` to a confined directory handle and a relative
+    /// path within it, or rejects it if it falls outside all allowed directories.
+    ///
+    /// The actual confinement is enforced by `cap-std`: the returned `Dir` can
+    /// only access its own subtree, so a symlink (existing, dangling, or raced)
+    /// cannot escape it.
+    pub async fn resolve(&self, requested_path: &Path) -> ServiceResult<Resolved> {
+        let allowed = self.allowed_dirs.read().await.clone();
+        if allowed.is_empty() {
             return Err(ServiceError::FromString(
-                "Allowed directories list is empty. Client did not provide any valid root directories.".to_string()
+                "Allowed directories list is empty. Client did not provide any valid root directories.".to_string(),
             ));
         }
 
@@ -65,49 +193,84 @@ impl FileSystemService {
         let expanded_path = expand_home(normalize_windows_drive_path(requested_path));
 
         // Resolve the absolute path
-        let absolute_path = if expanded_path.as_path().is_absolute() {
-            expanded_path.clone()
+        let absolute_path = if expanded_path.is_absolute() {
+            expanded_path
         } else {
-            env::current_dir().unwrap().join(&expanded_path)
+            env::current_dir()
+                .map_err(ServiceError::from)?
+                .join(&expanded_path)
         };
 
-        // Normalize the path
-        let normalized_requested = normalize_path(&absolute_path);
+        // Resolve to a canonical path. If the full path cannot be canonicalized
+        // (e.g. it does not exist yet), canonicalize the deepest existing
+        // ancestor and re-join the remaining suffix lexically. This mapping is
+        // used only to select the root and relative path; the security boundary
+        // is enforced by `cap-std` on the returned `Dir`.
+        let canonical = match absolute_path.canonicalize() {
+            Ok(canonical) => canonical,
+            Err(_) => {
+                let mut suffix: Vec<std::ffi::OsString> = Vec::new();
+                let mut ancestor = absolute_path.as_path();
+                let canonical_ancestor = loop {
+                    match ancestor.canonicalize() {
+                        Ok(canonical) => break canonical,
+                        Err(_) => {
+                            let file_name = ancestor.file_name().ok_or_else(|| {
+                                ServiceError::FromString(
+                                    "Invalid path: cannot resolve a non-existent path".into(),
+                                )
+                            })?;
+                            suffix.push(file_name.to_os_string());
+                            let parent = ancestor.parent().ok_or_else(|| {
+                                ServiceError::FromString("Invalid path".into())
+                            })?;
+                            if parent == ancestor {
+                                return Err(ServiceError::FromString(
+                                    "Invalid path: cannot resolve a non-existent path".into(),
+                                ));
+                            }
+                            ancestor = parent;
+                        }
+                    }
+                };
 
-        // Defence-in-depth: reject paths with unresolved parent directory components
-        if normalized_requested
-            .components()
-            .any(|c| c == Component::ParentDir)
-        {
-            return Err(ServiceError::FromString(
-                "Path contains unresolved parent directory components".into(),
-            ));
+                let mut result = canonical_ancestor;
+                for component in suffix.iter().rev() {
+                    result.push(component);
+                }
+                result
+            }
+        };
+
+        for allowed_dir in allowed.iter() {
+            if let Ok(rel) = canonical.strip_prefix(&allowed_dir.path) {
+                // Defence-in-depth: reject unresolved parent directory components.
+                if rel
+                    .components()
+                    .any(|c| c == Component::ParentDir)
+                {
+                    return Err(ServiceError::FromString(
+                        "Path contains unresolved parent directory components".into(),
+                    ));
+                }
+
+                return Ok(Resolved {
+                    dir: allowed_dir.dir.try_clone().map_err(ServiceError::from)?,
+                    rel: rel.to_path_buf(),
+                    display: canonical,
+                });
+            }
         }
 
-        // Check if path is within allowed directories
-        if !allowed_directories.iter().any(|dir| {
-            // Must account for both scenarios - the requested path may not exist yet, making canonicalization impossible.
-            normalized_requested.starts_with(dir)
-                || normalized_requested.starts_with(normalize_path(dir))
-        }) {
-            let symlink_target = if contains_symlink(&absolute_path)? {
-                "a symlink target path"
-            } else {
-                "path"
-            };
-            return Err(ServiceError::FromString(format!(
-                "Access denied - {} is outside allowed directories: {} not in {}",
-                symlink_target,
-                absolute_path.display(),
-                allowed_directories
-                    .iter()
-                    .map(|p| p.display().to_string())
-                    .collect::<Vec<_>>()
-                    .join(",\n"),
-            )));
-        }
-
-        Ok(normalized_requested)
+        Err(ServiceError::FromString(format!(
+            "Access denied - path is outside allowed directories: {} not in {}",
+            absolute_path.display(),
+            allowed
+                .iter()
+                .map(|ad| ad.path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(",\n"),
+        )))
     }
 
     pub fn valid_roots(&self, roots: Vec<&str>) -> ServiceResult<(Vec<PathBuf>, Option<String>)> {

--- a/src/fs_service/core.rs
+++ b/src/fs_service/core.rs
@@ -5,8 +5,7 @@ use crate::{
 use cap_std::{ambient_authority, fs::Dir};
 use std::{
     collections::HashSet,
-    env,
-    io,
+    env, io,
     path::{Component, Path, PathBuf},
     sync::Arc,
 };
@@ -221,9 +220,9 @@ impl FileSystemService {
                                 )
                             })?;
                             suffix.push(file_name.to_os_string());
-                            let parent = ancestor.parent().ok_or_else(|| {
-                                ServiceError::FromString("Invalid path".into())
-                            })?;
+                            let parent = ancestor
+                                .parent()
+                                .ok_or_else(|| ServiceError::FromString("Invalid path".into()))?;
                             if parent == ancestor {
                                 return Err(ServiceError::FromString(
                                     "Invalid path: cannot resolve a non-existent path".into(),
@@ -245,10 +244,7 @@ impl FileSystemService {
         for allowed_dir in allowed.iter() {
             if let Ok(rel) = canonical.strip_prefix(&allowed_dir.path) {
                 // Defence-in-depth: reject unresolved parent directory components.
-                if rel
-                    .components()
-                    .any(|c| c == Component::ParentDir)
-                {
+                if rel.components().any(|c| c == Component::ParentDir) {
                     return Err(ServiceError::FromString(
                         "Path contains unresolved parent directory components".into(),
                     ));

--- a/src/fs_service/io/edit.rs
+++ b/src/fs_service/io/edit.rs
@@ -46,11 +46,10 @@ impl FileSystemService {
         save_to: Option<&Path>,
         replace_all: Option<bool>,
     ) -> ServiceResult<String> {
-        let allowed_directories = self.allowed_directories().await;
-        let valid_path = self.validate_path(file_path, allowed_directories.clone())?;
+        let resolved = self.resolve(file_path).await?;
 
         // Read file content and normalize line endings
-        let content_str = tokio::fs::read_to_string(&valid_path).await?;
+        let content_str = resolved.dir.read_to_string(&resolved.rel)?;
         let original_line_ending = detect_line_ending(&content_str);
         let content_str = normalize_line_endings(&content_str);
 
@@ -275,7 +274,7 @@ impl FileSystemService {
         let diff = self.create_unified_diff(
             &content_str,
             &modified_content,
-            Some(valid_path.display().to_string()),
+            Some(resolved.display.display().to_string()),
         );
 
         // Format diff with appropriate number of backticks
@@ -293,13 +292,17 @@ impl FileSystemService {
         let is_dry_run = dry_run.unwrap_or(false);
 
         if !is_dry_run {
-            let target = if let Some(save_to_path) = save_to {
-                self.validate_path(save_to_path, allowed_directories)?
-            } else {
-                valid_path.as_path().to_path_buf()
-            };
             let modified_content = modified_content.replace("\n", original_line_ending);
-            tokio::fs::write(target, modified_content).await?;
+            if let Some(save_to_path) = save_to {
+                let resolved_save_to = self.resolve(save_to_path).await?;
+                resolved_save_to
+                    .dir
+                    .write(&resolved_save_to.rel, modified_content.as_bytes())?;
+            } else {
+                resolved
+                    .dir
+                    .write(&resolved.rel, modified_content.as_bytes())?;
+            }
         }
 
         Ok(formatted_diff)

--- a/src/fs_service/io/read.rs
+++ b/src/fs_service/io/read.rs
@@ -8,8 +8,8 @@ use crate::{
 use futures::{StreamExt, stream};
 use std::fs::{self};
 use std::io::SeekFrom;
-use std::time::SystemTime;
 use std::path::Path;
+use std::time::SystemTime;
 use tokio::{
     fs::File,
     io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, BufReader},
@@ -28,7 +28,11 @@ fn open_tokio(resolved: &crate::fs_service::Resolved) -> ServiceResult<File> {
 fn std_metadata(resolved: &crate::fs_service::Resolved) -> ServiceResult<fs::Metadata> {
     match resolved.dir.open(&resolved.rel) {
         Ok(file) => Ok(file.into_std().metadata()?),
-        Err(_) => Ok(resolved.dir.open_dir(&resolved.rel)?.into_std_file().metadata()?),
+        Err(_) => Ok(resolved
+            .dir
+            .open_dir(&resolved.rel)?
+            .into_std_file()
+            .metadata()?),
     }
 }
 

--- a/src/fs_service/io/read.rs
+++ b/src/fs_service/io/read.rs
@@ -1,17 +1,15 @@
 use crate::{
-    error::ServiceResult,
+    error::{ServiceError, ServiceResult},
     fs_service::{
         FileSystemService,
-        utils::{
-            format_permissions, format_system_time, mime_from_path, read_file_as_base64,
-            validate_file_size,
-        },
+        utils::{encode_base64, format_permissions, format_system_time, mime_from_bytes},
     },
 };
 use futures::{StreamExt, stream};
 use std::fs::{self};
+use std::io::SeekFrom;
 use std::time::SystemTime;
-use std::{io::SeekFrom, path::Path};
+use std::path::Path;
 use tokio::{
     fs::File,
     io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, BufReader},
@@ -19,15 +17,29 @@ use tokio::{
 
 const MAX_CONCURRENT_FILE_READ: usize = 5;
 
+/// Opens a resolved path for reading as a `tokio` file, confining access to
+/// the directory handle that `resolved` was opened from.
+fn open_tokio(resolved: &crate::fs_service::Resolved) -> ServiceResult<File> {
+    let std_file = resolved.dir.open(&resolved.rel)?.into_std();
+    Ok(File::from_std(std_file))
+}
+
+/// Returns `std::fs::Metadata` for a resolved path (file or directory).
+fn std_metadata(resolved: &crate::fs_service::Resolved) -> ServiceResult<fs::Metadata> {
+    match resolved.dir.open(&resolved.rel) {
+        Ok(file) => Ok(file.into_std().metadata()?),
+        Err(_) => Ok(resolved.dir.open_dir(&resolved.rel)?.into_std_file().metadata()?),
+    }
+}
+
 impl FileSystemService {
     pub async fn read_text_file(
         &self,
         file_path: &Path,
         with_line_numbers: bool,
     ) -> ServiceResult<String> {
-        let allowed_directories = self.allowed_directories().await;
-        let valid_path = self.validate_path(file_path, allowed_directories)?;
-        let content = tokio::fs::read_to_string(valid_path).await?;
+        let resolved = self.resolve(file_path).await?;
+        let content = resolved.dir.read_to_string(&resolved.rel)?;
 
         if with_line_numbers {
             Ok(content
@@ -47,12 +59,10 @@ impl FileSystemService {
     ///     n: Number of lines to read
     /// Returns a String containing the first n lines with original line endings or an error if the path is invalid or file cannot be read.
     pub async fn head_file(&self, file_path: &Path, n: usize) -> ServiceResult<String> {
-        // Validate file path against allowed directories
-        let allowed_directories = self.allowed_directories().await;
-        let valid_path = self.validate_path(file_path, allowed_directories)?;
+        let resolved = self.resolve(file_path).await?;
 
         // Open file asynchronously and create a BufReader
-        let file = File::open(&valid_path).await?;
+        let file = open_tokio(&resolved)?;
         let mut reader = BufReader::new(file);
         let mut result = String::with_capacity(n * 100); // Estimate capacity (avg 100 bytes/line)
         let mut count = 0;
@@ -78,12 +88,10 @@ impl FileSystemService {
     ///     n: Number of lines to read
     /// Returns a String containing the last n lines with original line endings or an error if the path is invalid or file cannot be read.
     pub async fn tail_file(&self, file_path: &Path, n: usize) -> ServiceResult<String> {
-        // Validate file path against allowed directories
-        let allowed_directories = self.allowed_directories().await;
-        let valid_path = self.validate_path(file_path, allowed_directories)?;
+        let resolved = self.resolve(file_path).await?;
 
         // Open file asynchronously
-        let file = File::open(&valid_path).await?;
+        let file = open_tokio(&resolved)?;
         let file_size = file.metadata().await?.len();
 
         // If file is empty or n is 0, return empty string
@@ -117,7 +125,7 @@ impl FileSystemService {
 
         // Check if file ends with a non-newline character (partial last line)
         if file_size > 0 {
-            let mut temp_reader = BufReader::new(File::open(&valid_path).await?);
+            let mut temp_reader = BufReader::new(open_tokio(&resolved)?);
             temp_reader.seek(SeekFrom::End(-1)).await?;
             let mut last_byte = [0u8; 1];
             temp_reader.read_exact(&mut last_byte).await?;
@@ -168,12 +176,10 @@ impl FileSystemService {
         offset: usize,
         limit: Option<usize>,
     ) -> ServiceResult<String> {
-        // Validate file path against allowed directories
-        let allowed_directories = self.allowed_directories().await;
-        let valid_path = self.validate_path(path, allowed_directories)?;
+        let resolved = self.resolve(path).await?;
 
         // Open file and get metadata before moving into BufReader
-        let file = File::open(&valid_path).await?;
+        let file = open_tokio(&resolved)?;
         let file_size = file.metadata().await?.len();
         let mut reader = BufReader::new(file);
 
@@ -242,20 +248,25 @@ impl FileSystemService {
         file_path: &Path,
         max_bytes: Option<usize>,
     ) -> ServiceResult<(infer::Type, String)> {
-        let allowed_directories = self.allowed_directories().await;
-        let valid_path = self.validate_path(file_path, allowed_directories)?;
-        validate_file_size(&valid_path, None, max_bytes).await?;
-        let kind = mime_from_path(&valid_path)?;
-        let content = read_file_as_base64(&valid_path).await?;
+        let resolved = self.resolve(file_path).await?;
+        let bytes = resolved.dir.read(&resolved.rel)?;
+
+        if let Some(max) = max_bytes
+            && bytes.len() > max
+        {
+            return Err(ServiceError::FileTooLarge(max));
+        }
+
+        let kind = mime_from_bytes(&bytes, &resolved.rel)?;
+        let content = encode_base64(&bytes);
         Ok((kind, content))
     }
 
     // Get file stats
     pub async fn get_file_stats(&self, file_path: &Path) -> ServiceResult<FileInfo> {
-        let allowed_directories = self.allowed_directories().await;
-        let valid_path = self.validate_path(file_path, allowed_directories)?;
+        let resolved = self.resolve(file_path).await?;
 
-        let metadata = std::fs::metadata(valid_path)?;
+        let metadata = std_metadata(&resolved)?;
 
         let size = metadata.len();
         let created = metadata.created().ok();

--- a/src/fs_service/io/write.rs
+++ b/src/fs_service/io/write.rs
@@ -3,24 +3,26 @@ use std::path::Path;
 
 impl FileSystemService {
     pub async fn write_file(&self, file_path: &Path, content: &String) -> ServiceResult<()> {
-        let allowed_directories = self.allowed_directories().await;
-        let valid_path = self.validate_path(file_path, allowed_directories)?;
-        tokio::fs::write(valid_path, content).await?;
+        let resolved = self.resolve(file_path).await?;
+        resolved.dir.write(&resolved.rel, content.as_bytes())?;
         Ok(())
     }
 
     pub async fn create_directory(&self, file_path: &Path) -> ServiceResult<()> {
-        let allowed_directories = self.allowed_directories().await;
-        let valid_path = self.validate_path(file_path, allowed_directories)?;
-        tokio::fs::create_dir_all(valid_path).await?;
+        let resolved = self.resolve(file_path).await?;
+        resolved.dir.create_dir_all(&resolved.rel)?;
         Ok(())
     }
 
     pub async fn move_file(&self, src_path: &Path, dest_path: &Path) -> ServiceResult<()> {
-        let allowed_directories = self.allowed_directories().await;
-        let valid_src_path = self.validate_path(src_path, allowed_directories.clone())?;
-        let valid_dest_path = self.validate_path(dest_path, allowed_directories)?;
-        tokio::fs::rename(valid_src_path, valid_dest_path).await?;
+        let resolved_src = self.resolve(src_path).await?;
+        let resolved_dest = self.resolve(dest_path).await?;
+
+        // Rename across the same or different allowed roots. `cap_std` confines
+        // both source and destination, so a symlink cannot redirect either.
+        resolved_src
+            .dir
+            .rename(&resolved_src.rel, &resolved_dest.dir, &resolved_dest.rel)?;
         Ok(())
     }
 }

--- a/src/fs_service/search/content.rs
+++ b/src/fs_service/search/content.rs
@@ -41,12 +41,14 @@ impl FileSystemService {
     ///
     /// If matched line is larger than 255 characters, a snippet will be extracted around the matched text.
     ///
-    pub fn content_search(
+    pub async fn content_search(
         &self,
         query: &str,
         file_path: impl AsRef<Path>,
         is_regex: Option<bool>,
     ) -> ServiceResult<Option<FileSearchResult>> {
+        let resolved = self.resolve(file_path.as_ref()).await?;
+
         let query = if is_regex.unwrap_or_default() {
             query.to_string()
         } else {
@@ -59,15 +61,19 @@ impl FileSystemService {
 
         let mut searcher = Searcher::new();
         let mut result = FileSearchResult {
-            file_path: file_path.as_ref().to_path_buf(),
+            file_path: resolved.display.clone(),
             matches: vec![],
         };
 
         searcher.set_binary_detection(BinaryDetection::quit(b'\x00'));
 
-        searcher.search_path(
+        // Open through the confined directory handle and search the reader,
+        // so the search cannot escape the allowed directory via a symlink.
+        let file = resolved.dir.open(&resolved.rel)?.into_std();
+
+        searcher.search_reader(
             &matcher,
-            file_path,
+            file,
             UTF8(|line_number, line| {
                 let actual_match = matcher.find(line.as_bytes())?.unwrap();
 
@@ -88,11 +94,6 @@ impl FileSystemService {
     }
 
     /// Extracts a snippet from a given line of text around a match.
-    ///
-    /// It extracts a substring starting a fixed number of characters (`SNIPPET_BACKWARD_CHARS`)
-    /// before the start position of the `match`, and extends up to `max_length` characters
-    /// If the snippet does not include the beginning or end of the original line, ellipses (`"..."`) are added
-    /// to indicate the truncation.
     pub fn extract_snippet(
         &self,
         line: &str,
@@ -109,12 +110,9 @@ impl FileSystemService {
         let line = line.trim();
 
         // Calculate the desired start byte index by adjusting match start for trimming and backward chars
-        // match_result.start() is the byte index in the original string
-        // Subtract start_pos to account for trimmed whitespace and backward_chars to include context before the match
         let desired_start = (match_result.start() - start_pos).saturating_sub(backward_chars);
 
         // Find the nearest valid UTF-8 character boundary at or after desired_start
-        // Prevents "byte index is not a char boundary" panic by ensuring the slice starts at a valid character (issue #37)
         let snippet_start = line
             .char_indices()
             .map(|(i, _)| i)
@@ -124,7 +122,6 @@ impl FileSystemService {
         let mut char_count = 0;
 
         // Calculate the desired end byte index by counting max_length characters from snippet_start
-        // Take max_length + 1 to find the boundary after the last desired character
         let desired_end = line[snippet_start..]
             .char_indices()
             .take(max_length + 1)
@@ -136,7 +133,6 @@ impl FileSystemService {
             .unwrap_or(line.len());
 
         // Ensure snippet_end is a valid UTF-8 character boundary at or after desired_end
-        // This prevents slicing issues with multi-byte characters
         let snippet_end = line
             .char_indices()
             .map(|(i, _)| i)
@@ -175,23 +171,22 @@ impl FileSystemService {
         min_bytes: Option<u64>,
         max_bytes: Option<u64>,
     ) -> ServiceResult<Vec<FileSearchResult>> {
-        let files_iter = self
+        let entries = self
             .search_files_iter(
                 root_path.as_ref(),
                 pattern.to_string(),
-                exclude_patterns.to_owned().unwrap_or_default(),
+                exclude_patterns.unwrap_or_default(),
                 min_bytes,
                 max_bytes,
             )
             .await?;
 
-        let results: Vec<FileSearchResult> = files_iter
-            .filter_map(|entry| {
-                self.content_search(query, entry.path(), Some(is_regex))
-                    .ok()
-                    .and_then(|v| v)
-            })
-            .collect();
+        let mut results: Vec<FileSearchResult> = Vec::new();
+        for entry in entries.into_iter().filter(|e| e.is_file()) {
+            if let Ok(Some(result)) = self.content_search(query, &entry.display, Some(is_regex)).await {
+                results.push(result);
+            }
+        }
         Ok(results)
     }
 }

--- a/src/fs_service/search/content.rs
+++ b/src/fs_service/search/content.rs
@@ -183,7 +183,10 @@ impl FileSystemService {
 
         let mut results: Vec<FileSearchResult> = Vec::new();
         for entry in entries.into_iter().filter(|e| e.is_file()) {
-            if let Ok(Some(result)) = self.content_search(query, &entry.display, Some(is_regex)).await {
+            if let Ok(Some(result)) = self
+                .content_search(query, &entry.display, Some(is_regex))
+                .await
+            {
                 results.push(result);
             }
         }

--- a/src/fs_service/search/files.rs
+++ b/src/fs_service/search/files.rs
@@ -1,27 +1,14 @@
 use crate::{
     error::ServiceResult,
-    fs_service::{FileSystemService, utils::filesize_in_range},
+    fs_service::{FileSystemService, FsEntry, utils::filesize_in_range, walk_dir},
 };
 use glob_match::glob_match;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use sha2::{Digest, Sha256};
-use std::{collections::HashMap, path::Path};
-use tokio::{fs::File, io::AsyncReadExt};
-use walkdir::WalkDir;
+use std::{collections::HashMap, io::Read, path::Path};
 
 impl FileSystemService {
     /// Searches for files in the directory tree starting at `root_path` that match the given `pattern`,
     /// excluding paths that match any of the `exclude_patterns`.
-    ///
-    /// # Arguments
-    /// * `root_path` - The root directory to start the search from.
-    /// * `pattern` - A glob pattern to match file names (case-insensitive). If no wildcards are provided,
-    ///   the pattern is wrapped in '*' for partial matching.
-    /// * `exclude_patterns` - A list of glob patterns to exclude paths (case-sensitive).
-    ///
-    /// # Returns
-    /// A `ServiceResult` containing a vector of`walkdir::DirEntry` objects for matching files,
-    /// or a `ServiceError` if an error occurs.
     pub async fn search_files(
         &self,
         root_path: &Path,
@@ -29,35 +16,25 @@ impl FileSystemService {
         exclude_patterns: Vec<String>,
         min_bytes: Option<u64>,
         max_bytes: Option<u64>,
-    ) -> ServiceResult<Vec<walkdir::DirEntry>> {
-        let result = self
-            .search_files_iter(root_path, pattern, exclude_patterns, min_bytes, max_bytes)
-            .await?;
-        Ok(result.collect::<Vec<walkdir::DirEntry>>())
+    ) -> ServiceResult<Vec<FsEntry>> {
+        self.search_files_iter(root_path, pattern, exclude_patterns, min_bytes, max_bytes)
+            .await
     }
 
-    /// Returns an iterator over files in the directory tree starting at `root_path` that match
-    /// the given `pattern`, excluding paths that match any of the `exclude_patterns`.
+    /// Returns files and directories in the tree rooted at `root_path` matching
+    /// the given `pattern`, excluding paths matching `exclude_patterns`.
     ///
-    /// # Arguments
-    /// * `root_path` - The root directory to start the search from.
-    /// * `pattern` - A glob pattern to match file names. If no wildcards are provided, the pattern is wrapped in `**/*{pattern}*` for partial matching.
-    /// * `exclude_patterns` - A list of glob patterns to exclude paths (case-sensitive).
-    ///
-    /// # Returns
-    /// A `ServiceResult` containing an iterator yielding `walkdir::DirEntry` objects for matching files,
-    /// or a `ServiceError` if an error occurs.
-    pub async fn search_files_iter<'a>(
-        &'a self,
-        // root_path: impl Into<PathBuf>,
-        root_path: &'a Path,
+    /// Traversal is confined to the allowed directory by `cap-std`, so symlink
+    /// escapes are never followed.
+    pub async fn search_files_iter(
+        &self,
+        root_path: &Path,
         pattern: String,
         exclude_patterns: Vec<String>,
         min_bytes: Option<u64>,
         max_bytes: Option<u64>,
-    ) -> ServiceResult<impl Iterator<Item = walkdir::DirEntry> + 'a> {
-        let allowed_directories = self.allowed_directories().await;
-        let valid_path = self.validate_path(root_path, allowed_directories.clone())?;
+    ) -> ServiceResult<Vec<FsEntry>> {
+        let resolved = self.resolve(root_path).await?;
 
         let updated_pattern = if pattern.contains('*') {
             pattern.to_lowercase()
@@ -66,69 +43,47 @@ impl FileSystemService {
         };
         let glob_pattern = updated_pattern;
 
-        let result = WalkDir::new(valid_path)
-            .follow_links(true)
-            .into_iter()
-            .filter_entry(move |dir_entry| {
-                let full_path = dir_entry.path();
+        // Confined recursive traversal.
+        let mut all_entries = Vec::new();
+        walk_dir(&resolved.dir, &resolved.rel, &resolved.display, &mut all_entries)?;
 
-                // Validate each path before processing
-                let validated_path = self
-                    .validate_path(full_path, allowed_directories.clone())
-                    .ok();
+        let mut result = Vec::new();
+        for entry in all_entries {
+            // Compute the path relative to the search root for exclusion matching.
+            let relative_path = entry.rel.strip_prefix(&resolved.rel).unwrap_or(&entry.rel);
 
-                if validated_path.is_none() {
-                    // Skip invalid paths during search
-                    return false;
-                }
-
-                // Get the relative path from the root_path
-                let relative_path = full_path.strip_prefix(root_path).unwrap_or(full_path);
-
-                let mut should_exclude = exclude_patterns.iter().any(|pattern| {
-                    let glob_pattern = if pattern.contains('*') {
-                        pattern.strip_prefix("/").unwrap_or(pattern).to_owned()
-                    } else {
-                        format!("*{pattern}*")
-                    };
-
-                    glob_match(&glob_pattern, relative_path.to_str().unwrap_or(""))
-                });
-
-                // enforce min/max bytes
-                if !should_exclude && (min_bytes.is_none() || max_bytes.is_none()) {
-                    match dir_entry.metadata().ok() {
-                        Some(metadata) => {
-                            if !filesize_in_range(metadata.len(), min_bytes, max_bytes) {
-                                should_exclude = true;
-                            }
-                        }
-                        None => {
-                            should_exclude = true;
-                        }
-                    }
-                }
-
-                !should_exclude
-            })
-            .filter_map(|v| v.ok())
-            .filter(move |entry| {
-                if root_path == entry.path() {
-                    return false;
-                }
-
-                glob_match(
-                    &glob_pattern,
-                    &entry.file_name().to_str().unwrap_or("").to_lowercase(),
-                )
+            let should_exclude = exclude_patterns.iter().any(|pattern| {
+                let glob_pattern = if pattern.contains('*') {
+                    pattern.strip_prefix('/').unwrap_or(pattern).to_owned()
+                } else {
+                    format!("*{pattern}*")
+                };
+                glob_match(&glob_pattern, relative_path.to_str().unwrap_or(""))
             });
+
+            if should_exclude {
+                continue;
+            }
+
+            // Enforce min/max bytes for files.
+            if !entry.is_dir
+                && (min_bytes.is_some() || max_bytes.is_some())
+                && !filesize_in_range(entry.len, min_bytes, max_bytes)
+            {
+                continue;
+            }
+
+            if !glob_match(&glob_pattern, &entry.file_name.to_lowercase()) {
+                continue;
+            }
+
+            result.push(entry);
+        }
 
         Ok(result)
     }
 
     /// Finds groups of duplicate files within the given root path.
-    /// Returns a vector of vectors, where each inner vector contains paths to files with identical content.
-    /// Files are considered duplicates if they have the same size and SHA-256 hash.
     pub async fn find_duplicate_files(
         &self,
         root_path: &Path,
@@ -137,112 +92,72 @@ impl FileSystemService {
         min_bytes: Option<u64>,
         max_bytes: Option<u64>,
     ) -> ServiceResult<Vec<Vec<String>>> {
-        // Validate root path against allowed directories
-        let allowed_directories = self.allowed_directories().await;
-        let valid_path = self.validate_path(root_path, allowed_directories)?;
-
-        // Get Tokio runtime handle
-        let rt = tokio::runtime::Handle::current();
-
-        // Step 1: Collect files and group by size
-        let mut size_map: HashMap<u64, Vec<String>> = HashMap::new();
         let entries = self
             .search_files_iter(
-                &valid_path,
+                root_path,
                 pattern.unwrap_or("**/*".to_string()),
                 exclude_patterns.unwrap_or_default(),
                 min_bytes,
                 max_bytes,
             )
-            .await?
-            .filter(|e| e.file_type().is_file()); // Only files
+            .await?;
 
-        for entry in entries {
-            if let Ok(metadata) = entry.metadata()
-                && let Some(path_str) = entry.path().to_str()
-            {
-                size_map
-                    .entry(metadata.len())
-                    .or_default()
-                    .push(path_str.to_string());
+        // Step 1: Group files by size.
+        let mut size_map: HashMap<u64, Vec<FsEntry>> = HashMap::new();
+        for entry in entries.into_iter().filter(|e| e.is_file()) {
+            size_map.entry(entry.len).or_default().push(entry);
+        }
+
+        // Filter out sizes with only one file.
+        let mut duplicate_groups: Vec<Vec<String>> = Vec::new();
+        for (_size, mut group) in size_map.into_iter().filter(|(_, g)| g.len() > 1) {
+            // Step 2: Group by SHA-256 of the first 4KB.
+            let mut quick_map: HashMap<Vec<u8>, Vec<FsEntry>> = HashMap::new();
+            for entry in group.drain(..) {
+                let hash = match quick_hash(&entry) {
+                    Some(h) => h,
+                    None => continue,
+                };
+                quick_map.entry(hash).or_default().push(entry);
+            }
+
+            // Step 3: For groups with multiple files, group by full hash.
+            for (_quick, mut quick_group) in quick_map.into_iter().filter(|(_, g)| g.len() > 1) {
+                let mut full_map: HashMap<Vec<u8>, Vec<String>> = HashMap::new();
+                for entry in quick_group.drain(..) {
+                    if let (Some(hash), Some(path)) = (full_hash(&entry), entry.display.to_str()) {
+                        full_map.entry(hash).or_default().push(path.to_string());
+                    }
+                }
+                for (_hash, paths) in full_map.into_iter().filter(|(_, p)| p.len() > 1) {
+                    duplicate_groups.push(paths);
+                }
             }
         }
 
-        // Filter out sizes with only one file (no duplicates possible)
-        let size_groups: Vec<Vec<String>> = size_map
-            .into_iter()
-            .collect::<Vec<_>>() // Collect into Vec to enable parallel iteration
-            .into_par_iter()
-            .filter(|(_, paths)| paths.len() > 1)
-            .map(|(_, paths)| paths)
-            .collect();
-
-        // Step 2: Group by quick hash (first 4KB)
-        let mut quick_hash_map: HashMap<Vec<u8>, Vec<String>> = HashMap::new();
-        for paths in size_groups.into_iter() {
-            let quick_hashes: Vec<(String, Vec<u8>)> = paths
-                .into_par_iter()
-                .filter_map(|path| {
-                    let rt = rt.clone(); // Clone the runtime handle for this task
-                    rt.block_on(async {
-                        let file = File::open(&path).await.ok()?;
-                        let mut reader = tokio::io::BufReader::new(file);
-                        let mut buffer = vec![0u8; 4096]; // Read first 4KB
-                        let bytes_read = reader.read(&mut buffer).await.ok()?;
-                        let mut hasher = Sha256::new();
-                        hasher.update(&buffer[..bytes_read]);
-                        Some((path, hasher.finalize().to_vec()))
-                    })
-                })
-                .collect();
-
-            for (path, hash) in quick_hashes {
-                quick_hash_map.entry(hash).or_default().push(path);
-            }
-        }
-
-        // Step 3: Group by full hash for groups with multiple files
-        let mut full_hash_map: HashMap<Vec<u8>, Vec<String>> = HashMap::new();
-        let filtered_quick_hashes: Vec<(Vec<u8>, Vec<String>)> = quick_hash_map
-            .into_iter()
-            .collect::<Vec<_>>()
-            .into_par_iter()
-            .filter(|(_, paths)| paths.len() > 1)
-            .collect();
-
-        for (_quick_hash, paths) in filtered_quick_hashes {
-            let full_hashes: Vec<(String, Vec<u8>)> = paths
-                .into_par_iter()
-                .filter_map(|path| {
-                    let rt = rt.clone(); // Clone the runtime handle for this task
-                    rt.block_on(async {
-                        let file = File::open(&path).await.ok()?;
-                        let mut reader = tokio::io::BufReader::new(file);
-                        let mut hasher = Sha256::new();
-                        let mut buffer = vec![0u8; 8192]; // 8KB chunks
-                        loop {
-                            let bytes_read = reader.read(&mut buffer).await.ok()?;
-                            if bytes_read == 0 {
-                                break;
-                            }
-                            hasher.update(&buffer[..bytes_read]);
-                        }
-                        Some((path, hasher.finalize().to_vec()))
-                    })
-                })
-                .collect();
-
-            for (path, hash) in full_hashes {
-                full_hash_map.entry(hash).or_default().push(path);
-            }
-        }
-
-        // Collect groups of duplicates (only groups with more than one file)
-        let duplicates: Vec<Vec<String>> = full_hash_map
-            .into_values()
-            .filter(|group| group.len() > 1)
-            .collect();
-
-        Ok(duplicates)
+        Ok(duplicate_groups)
     }
+}
+
+fn quick_hash(entry: &FsEntry) -> Option<Vec<u8>> {
+    let mut file = entry.open().ok()?.into_std();
+    let mut buffer = vec![0u8; 4096];
+    let bytes_read = file.read(&mut buffer).ok()?;
+    let mut hasher = Sha256::new();
+    hasher.update(&buffer[..bytes_read]);
+    Some(hasher.finalize().to_vec())
+}
+
+fn full_hash(entry: &FsEntry) -> Option<Vec<u8>> {
+    let mut file = entry.open().ok()?.into_std();
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0u8; 8192];
+    loop {
+        let bytes_read = file.read(&mut buffer).ok()?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
+    Some(hasher.finalize().to_vec())
 }

--- a/src/fs_service/search/files.rs
+++ b/src/fs_service/search/files.rs
@@ -45,7 +45,12 @@ impl FileSystemService {
 
         // Confined recursive traversal.
         let mut all_entries = Vec::new();
-        walk_dir(&resolved.dir, &resolved.rel, &resolved.display, &mut all_entries)?;
+        walk_dir(
+            &resolved.dir,
+            &resolved.rel,
+            &resolved.display,
+            &mut all_entries,
+        )?;
 
         let mut result = Vec::new();
         for entry in all_entries {

--- a/src/fs_service/search/tree.rs
+++ b/src/fs_service/search/tree.rs
@@ -1,197 +1,178 @@
 use crate::{
     error::{ServiceError, ServiceResult},
-    fs_service::{FileSystemService, utils::is_system_metadata_file},
+    fs_service::{FileSystemService, FsEntry, utils::is_system_metadata_file, walk_dir},
 };
-use rayon::iter::{ParallelBridge, ParallelIterator};
+use cap_std::fs::Dir;
+use glob_match::glob_match;
 use serde_json::{Value, json};
 use std::{
-    fs::{self},
     path::{Path, PathBuf},
-    sync::Arc,
 };
-use walkdir::WalkDir;
+
+fn is_excluded(exclude_patterns: &[String], rel: &Path) -> bool {
+    exclude_patterns.iter().any(|pattern| {
+        let glob = if pattern.contains('*') {
+            pattern.strip_prefix('/').unwrap_or(pattern).to_owned()
+        } else {
+            format!("*{pattern}*")
+        };
+        glob_match(&glob, rel.to_str().unwrap_or(""))
+    })
+}
 
 impl FileSystemService {
     /// Generates a JSON representation of a directory tree starting at the given path.
     ///
-    /// This function recursively builds a JSON array object representing the directory structure,
-    /// where each entry includes a `name` (file or directory name), `type` ("file" or "directory"),
-    /// and for directories, a `children` array containing their contents. Files do not have a
-    /// `children` field.
-    ///
     /// The function supports optional constraints to limit the tree size:
     /// - `max_depth`: Limits the depth of directory traversal.
     /// - `max_files`: Limits the total number of entries (files and directories).
-    ///
-    /// # IMPORTANT NOTE
-    ///
-    /// use max_depth or max_files could lead to partial or skewed representations of actual directory tree
-    pub fn directory_tree<P: AsRef<Path>>(
+    pub async fn directory_tree<P: AsRef<Path>>(
         &self,
         root_path: P,
         max_depth: Option<usize>,
         max_files: Option<usize>,
         current_count: &mut usize,
-        allowed_directories: Arc<Vec<PathBuf>>,
     ) -> ServiceResult<(Value, bool)> {
-        let valid_path = self.validate_path(root_path.as_ref(), allowed_directories.clone())?;
+        let resolved = self.resolve(root_path.as_ref()).await?;
 
-        let metadata = fs::metadata(&valid_path)?;
+        let metadata = if resolved.rel.as_os_str().is_empty() {
+            resolved.dir.dir_metadata()?
+        } else {
+            resolved.dir.metadata(&resolved.rel)?
+        };
         if !metadata.is_dir() {
             return Err(ServiceError::FromString(
                 "Root path must be a directory".into(),
             ));
         }
 
-        let mut children = Vec::new();
-        let mut reached_max_depth = false;
-
-        if max_depth != Some(0) {
-            for entry in WalkDir::new(valid_path)
-                .min_depth(1)
-                .max_depth(1)
-                .follow_links(true)
-                .into_iter()
-                .filter_map(|e| e.ok())
-            {
-                let child_path = entry.path();
-                let metadata = fs::metadata(child_path)?;
-
-                let entry_name = child_path
-                    .file_name()
-                    .ok_or(ServiceError::FromString("Invalid path".to_string()))?
-                    .to_string_lossy()
-                    .into_owned();
-
-                // Increment the count for this entry
-                *current_count += 1;
-
-                // Check if we've exceeded max_files (if set)
-                if let Some(max) = max_files
-                    && *current_count > max
-                {
-                    continue; // Skip this entry but continue processing others
-                }
-
-                let mut json_entry = json!({
-                    "name": entry_name,
-                    "type": if metadata.is_dir() { "directory" } else { "file" }
-                });
-
-                if metadata.is_dir() {
-                    let next_depth = max_depth.map(|d| d - 1);
-                    let (child_children, child_reached_max_depth) = self.directory_tree(
-                        child_path,
-                        next_depth,
-                        max_files,
-                        current_count,
-                        allowed_directories.clone(),
-                    )?;
-                    json_entry
-                        .as_object_mut()
-                        .unwrap()
-                        .insert("children".to_string(), child_children);
-                    reached_max_depth |= child_reached_max_depth;
-                }
-                children.push(json_entry);
-            }
-        } else {
-            // If max_depth is 0, we skip processing this directory's children
-            reached_max_depth = true;
-        }
+        let (children, reached_max_depth) =
+            self.build_tree(&resolved.dir, &resolved.rel, max_depth, max_files, current_count)?;
         Ok((Value::Array(children), reached_max_depth))
     }
 
+    #[allow(clippy::only_used_in_recursion)]
+    fn build_tree(
+        &self,
+        dir: &Dir,
+        rel: &Path,
+        max_depth: Option<usize>,
+        max_files: Option<usize>,
+        current_count: &mut usize,
+    ) -> ServiceResult<(Vec<Value>, bool)> {
+        let mut children = Vec::new();
+        let mut reached_max_depth = false;
+
+        if max_depth == Some(0) {
+            return Ok((children, true));
+        }
+
+        let read_dir = if rel.as_os_str().is_empty() {
+            dir.entries()?
+        } else {
+            dir.read_dir(rel)?
+        };
+        for entry in read_dir {
+            let entry = entry?;
+            let name = entry.file_name();
+            let entry_name = name.to_string_lossy().into_owned();
+
+            let child_rel = if rel.as_os_str().is_empty() {
+                PathBuf::from(&name)
+            } else {
+                rel.join(&name)
+            };
+
+            let child_meta = dir.metadata(&child_rel).ok();
+            let is_dir = child_meta.as_ref().is_some_and(|m| m.is_dir());
+
+            // Increment the count for this entry
+            *current_count += 1;
+
+            // Check if we've exceeded max_files (if set)
+            if let Some(max) = max_files
+                && *current_count > max
+            {
+                continue;
+            }
+
+            let mut json_entry = json!({
+                "name": entry_name,
+                "type": if is_dir { "directory" } else { "file" }
+            });
+
+            if is_dir {
+                let next_depth = max_depth.map(|d| d - 1);
+                let (child_children, child_reached_max_depth) = self.build_tree(
+                    dir,
+                    &child_rel,
+                    next_depth,
+                    max_files,
+                    current_count,
+                )?;
+                json_entry
+                    .as_object_mut()
+                    .unwrap()
+                    .insert("children".to_string(), Value::Array(child_children));
+                reached_max_depth |= child_reached_max_depth;
+            }
+            children.push(json_entry);
+        }
+
+        Ok((children, reached_max_depth))
+    }
+
     /// Calculates the total size (in bytes) of all files within a directory tree.
-    ///
-    /// This function recursively searches the specified `root_path` for files,
-    /// filters out directories and non-file entries, and sums the sizes of all found files.
-    /// The size calculation is parallelized using Rayon for improved performance on large directories.
-    ///
-    /// # Arguments
-    /// * `root_path` - The root directory path to start the size calculation.
-    ///
-    /// # Returns
-    /// Returns a `ServiceResult<u64>` containing the total size in bytes of all files under the `root_path`.
-    ///
-    /// # Notes
-    /// - Only files are included in the size calculation; directories and other non-file entries are ignored.
-    /// - The search pattern is `"**/*"` (all files) and no exclusions are applied.
-    /// - Parallel iteration is used to speed up the metadata fetching and summation.
     pub async fn calculate_directory_size(&self, root_path: &Path) -> ServiceResult<u64> {
         let entries = self
             .search_files_iter(root_path, "**/*".to_string(), vec![], None, None)
-            .await?
-            .filter(|e| e.file_type().is_file()); // Only process files
+            .await?;
 
-        // Use rayon to parallelize size summation
         let total_size: u64 = entries
-            .par_bridge() // Convert to parallel iterator
-            .filter_map(|entry| entry.metadata().ok().map(|meta| meta.len()))
+            .into_iter()
+            .filter(|e| e.is_file())
+            .map(|e| e.len)
             .sum();
 
         Ok(total_size)
     }
 
     /// Recursively finds all empty directories within the given root path.
-    ///
-    /// A directory is considered empty if it contains no files in itself or any of its subdirectories
-    /// except OS metadata files: `.DS_Store` (macOS) and `Thumbs.db` (Windows)
-    /// Empty subdirectories are allowed. You can optionally provide a list of glob-style patterns in
-    /// `exclude_patterns` to ignore certain paths during the search (e.g., to skip system folders or hidden directories).
-    ///
-    /// # Arguments
-    /// - `root_path`: The starting directory to search.
-    /// - `exclude_patterns`: Optional list of glob patterns to exclude from the search.
-    ///   Directories matching these patterns will be ignored.
-    ///
-    /// # Errors
-    /// Returns an error if the root path is invalid or inaccessible.
-    ///
-    /// # Returns
-    /// A list of paths to empty directories, as strings, including parent directories that contain only empty subdirectories.
-    /// Recursively finds all empty directories within the given root path.
-    ///
-    /// A directory is considered empty if it contains no files in itself or any of its subdirectories.
-    /// Empty subdirectories are allowed. You can optionally provide a list of glob-style patterns in
-    /// `exclude_patterns` to ignore certain paths during the search (e.g., to skip system folders or hidden directories).
-    ///
-    /// # Arguments
-    /// - `root_path`: The starting directory to search.
-    /// - `exclude_patterns`: Optional list of glob patterns to exclude from the search.
-    ///   Directories matching these patterns will be ignored.
-    ///
-    /// # Errors
-    /// Returns an error if the root path is invalid or inaccessible.
-    ///
-    /// # Returns
-    /// A list of paths to all empty directories, as strings, including parent directories that contain only empty subdirectories.
     pub async fn find_empty_directories(
         &self,
         root_path: &Path,
         exclude_patterns: Option<Vec<String>>,
     ) -> ServiceResult<Vec<String>> {
-        let walker = self
-            .search_files_iter(
-                root_path,
-                "**/*".to_string(),
-                exclude_patterns.unwrap_or_default(),
-                None,
-                None,
-            )
-            .await?
-            .filter(|e| e.file_type().is_dir()); // Only directories
+        let resolved = self.resolve(root_path).await?;
+
+        let exclude_patterns = exclude_patterns.unwrap_or_default();
+        let mut entries = Vec::new();
+        walk_dir(&resolved.dir, &resolved.rel, &resolved.display, &mut entries)?;
 
         let mut empty_dirs = Vec::new();
 
-        // Check each directory for emptiness
-        for entry in walker {
-            let is_empty = WalkDir::new(entry.path())
-                .into_iter()
-                .filter_map(|e| e.ok())
-                .all(|e| !e.file_type().is_file() || is_system_metadata_file(e.file_name())); // Directory is empty if no files are found in it or subdirs, ".DS_Store" will be ignores on Mac
+        for entry in &entries {
+            if !entry.is_dir {
+                continue;
+            }
 
-            if is_empty && let Some(path_str) = entry.path().to_str() {
+            // Relative path from the search root for exclusion matching.
+            let rel_from_root = entry.rel.strip_prefix(&resolved.rel).unwrap_or(&entry.rel);
+            if is_excluded(&exclude_patterns, rel_from_root) {
+                continue;
+            }
+
+            // A directory is empty if no non-metadata file is a strict descendant.
+            let has_file = entries.iter().any(|f| {
+                !f.is_dir
+                    && f.rel.starts_with(&entry.rel)
+                    && f.rel != entry.rel
+                    && !is_system_metadata_file(std::ffi::OsStr::new(f.file_name.as_str()))
+            });
+
+            if !has_file
+                && let Some(path_str) = entry.display.to_str()
+            {
                 empty_dirs.push(path_str.to_string());
             }
         }
@@ -199,18 +180,39 @@ impl FileSystemService {
         Ok(empty_dirs)
     }
 
-    pub async fn list_directory(&self, dir_path: &Path) -> ServiceResult<Vec<tokio::fs::DirEntry>> {
-        let allowed_directories = self.allowed_directories().await;
-
-        let valid_path = self.validate_path(dir_path, allowed_directories)?;
-
-        let mut dir = tokio::fs::read_dir(valid_path).await?;
+    pub async fn list_directory(&self, dir_path: &Path) -> ServiceResult<Vec<FsEntry>> {
+        let resolved = self.resolve(dir_path).await?;
 
         let mut entries = Vec::new();
+        let read_dir = if resolved.rel.as_os_str().is_empty() {
+            resolved.dir.entries()?
+        } else {
+            resolved.dir.read_dir(&resolved.rel)?
+        };
 
-        // Use a loop to collect the directory entries
-        while let Some(entry) = dir.next_entry().await? {
-            entries.push(entry);
+        for entry in read_dir {
+            let entry = entry?;
+            let name = entry.file_name();
+            let name_string = name.to_string_lossy().into_owned();
+
+            let rel = if resolved.rel.as_os_str().is_empty() {
+                PathBuf::from(&name)
+            } else {
+                resolved.rel.join(&name)
+            };
+
+            let meta = resolved.dir.metadata(&rel).ok();
+            let is_dir = meta.as_ref().is_some_and(|m| m.is_dir());
+            let len = meta.as_ref().map_or(0, |m| m.len());
+
+            entries.push(FsEntry {
+                dir: resolved.dir.try_clone()?,
+                rel,
+                display: resolved.display.join(&name),
+                file_name: name_string,
+                is_dir,
+                len,
+            });
         }
 
         Ok(entries)

--- a/src/fs_service/search/tree.rs
+++ b/src/fs_service/search/tree.rs
@@ -5,9 +5,7 @@ use crate::{
 use cap_std::fs::Dir;
 use glob_match::glob_match;
 use serde_json::{Value, json};
-use std::{
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 fn is_excluded(exclude_patterns: &[String], rel: &Path) -> bool {
     exclude_patterns.iter().any(|pattern| {
@@ -46,8 +44,13 @@ impl FileSystemService {
             ));
         }
 
-        let (children, reached_max_depth) =
-            self.build_tree(&resolved.dir, &resolved.rel, max_depth, max_files, current_count)?;
+        let (children, reached_max_depth) = self.build_tree(
+            &resolved.dir,
+            &resolved.rel,
+            max_depth,
+            max_files,
+            current_count,
+        )?;
         Ok((Value::Array(children), reached_max_depth))
     }
 
@@ -103,13 +106,8 @@ impl FileSystemService {
 
             if is_dir {
                 let next_depth = max_depth.map(|d| d - 1);
-                let (child_children, child_reached_max_depth) = self.build_tree(
-                    dir,
-                    &child_rel,
-                    next_depth,
-                    max_files,
-                    current_count,
-                )?;
+                let (child_children, child_reached_max_depth) =
+                    self.build_tree(dir, &child_rel, next_depth, max_files, current_count)?;
                 json_entry
                     .as_object_mut()
                     .unwrap()
@@ -147,7 +145,12 @@ impl FileSystemService {
 
         let exclude_patterns = exclude_patterns.unwrap_or_default();
         let mut entries = Vec::new();
-        walk_dir(&resolved.dir, &resolved.rel, &resolved.display, &mut entries)?;
+        walk_dir(
+            &resolved.dir,
+            &resolved.rel,
+            &resolved.display,
+            &mut entries,
+        )?;
 
         let mut empty_dirs = Vec::new();
 
@@ -170,9 +173,7 @@ impl FileSystemService {
                     && !is_system_metadata_file(std::ffi::OsStr::new(f.file_name.as_str()))
             });
 
-            if !has_file
-                && let Some(path_str) = entry.display.to_str()
-            {
+            if !has_file && let Some(path_str) = entry.display.to_str() {
                 empty_dirs.push(path_str.to_string());
             }
         }

--- a/src/fs_service/utils.rs
+++ b/src/fs_service/utils.rs
@@ -1,9 +1,8 @@
 use crate::error::{ServiceError, ServiceResult};
-use base64::{engine::general_purpose, write::EncoderWriter};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use chrono::{DateTime, Local};
 use dirs::home_dir;
 use rust_mcp_sdk::macros::JsonSchema;
-use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 #[cfg(windows)]
@@ -11,13 +10,8 @@ use std::os::windows::fs::MetadataExt;
 use std::{
     ffi::OsStr,
     fs::{self},
-    path::{Component, Path, PathBuf, Prefix},
+    path::{Path, PathBuf},
     time::SystemTime,
-};
-use tokio::io::AsyncReadExt;
-use tokio::{
-    fs::{File, metadata},
-    io::BufReader,
 };
 
 #[cfg(windows)]
@@ -69,19 +63,6 @@ pub fn format_permissions(metadata: &fs::Metadata) -> String {
 
         result
     }
-}
-
-pub fn normalize_path(path: &Path) -> PathBuf {
-    if let Ok(canonical) = path.canonicalize() {
-        return canonical;
-    }
-    if let Some(parent) = path.parent()
-        && let Ok(canonical_parent) = parent.canonicalize()
-        && let Some(file_name) = path.file_name()
-    {
-        return canonical_parent.join(file_name);
-    }
-    path.to_path_buf()
 }
 
 pub fn normalize_windows_drive_path(path: &Path) -> PathBuf {
@@ -170,41 +151,6 @@ pub fn normalize_line_endings(text: &str) -> String {
     text.replace("\r\n", "\n").replace('\r', "\n")
 }
 
-// checks if path component is a  Prefix::VerbatimDisk
-fn is_verbatim_disk(component: &Component) -> bool {
-    match component {
-        Component::Prefix(prefix_comp) => matches!(prefix_comp.kind(), Prefix::VerbatimDisk(_)),
-        _ => false,
-    }
-}
-
-/// Check path contains a symlink
-pub fn contains_symlink<P: AsRef<Path>>(path: P) -> std::io::Result<bool> {
-    let mut current_path = PathBuf::new();
-
-    for component in path.as_ref().components() {
-        current_path.push(component);
-
-        // no need to check symlink_metadata for Prefix::VerbatimDisk
-        if is_verbatim_disk(&component) {
-            continue;
-        }
-
-        if !current_path.exists() {
-            break;
-        }
-
-        if fs::symlink_metadata(&current_path)?
-            .file_type()
-            .is_symlink()
-        {
-            return Ok(true);
-        }
-    }
-
-    Ok(false)
-}
-
 /// Checks if a given filename is a system metadata file commonly
 /// used by operating systems to store folder metadata.
 ///
@@ -214,35 +160,6 @@ pub fn contains_symlink<P: AsRef<Path>>(path: P) -> std::io::Result<bool> {
 ///
 pub fn is_system_metadata_file(filename: &OsStr) -> bool {
     filename == ".DS_Store" || filename == "Thumbs.db"
-}
-
-// reads file as base64 efficiently in a streaming manner
-pub async fn read_file_as_base64(file_path: &Path) -> ServiceResult<String> {
-    let file = File::open(file_path).await?;
-    let mut reader = BufReader::new(file);
-
-    let mut output = Vec::new();
-    {
-        // Wrap output Vec<u8> in a Base64 encoder writer
-        let mut encoder = EncoderWriter::new(&mut output, &general_purpose::STANDARD);
-
-        let mut buffer = [0u8; 8192];
-        loop {
-            let n = reader.read(&mut buffer).await?;
-            if n == 0 {
-                break;
-            }
-            // Write raw bytes to the Base64 encoder
-            encoder.write_all(&buffer[..n])?;
-        }
-        // Make sure to flush any remaining bytes
-        encoder.flush()?;
-    } // drop encoder before consuming output
-
-    // Convert the Base64 bytes to String (safe UTF-8)
-    let base64_string =
-        String::from_utf8(output).map_err(|err| ServiceError::FromString(format!("{err}")))?;
-    Ok(base64_string)
 }
 
 pub fn detect_line_ending(text: &str) -> &str {
@@ -255,7 +172,7 @@ pub fn detect_line_ending(text: &str) -> &str {
     }
 }
 
-pub fn mime_from_path(path: &Path) -> ServiceResult<infer::Type> {
+pub fn mime_from_bytes(bytes: &[u8], path: &Path) -> ServiceResult<infer::Type> {
     let is_svg = path
         .extension()
         .is_some_and(|e| e.to_str().is_some_and(|s| s == "svg"));
@@ -267,13 +184,14 @@ pub fn mime_from_path(path: &Path) -> ServiceResult<infer::Type> {
             "svg",
             |_: &[u8]| true,
         ));
-
-        // infer::Type::new(infer::MatcherType::Image, "", "svg",);
     }
-    let kind = infer::get_from_path(path)?.ok_or(ServiceError::FromString(
-        "File tyle is unknown!".to_string(),
-    ))?;
-    Ok(kind)
+    infer::get(bytes).ok_or(ServiceError::FromString(
+        "File type is unknown!".to_string(),
+    ))
+}
+
+pub fn encode_base64(bytes: &[u8]) -> String {
+    STANDARD.encode(bytes)
 }
 
 pub fn escape_regex(text: &str) -> String {
@@ -302,24 +220,6 @@ pub fn filesize_in_range(file_size: u64, min_bytes: Option<u64>, max_bytes: Opti
         (_, Some(max)) if file_size > max => false,
         (Some(min), _) if file_size < min => false,
         _ => true,
-    }
-}
-
-pub async fn validate_file_size<P: AsRef<Path>>(
-    path: P,
-    min_bytes: Option<usize>,
-    max_bytes: Option<usize>,
-) -> ServiceResult<()> {
-    if min_bytes.is_none() && max_bytes.is_none() {
-        return Ok(());
-    }
-
-    let file_size = metadata(&path).await?.len() as usize;
-
-    match (min_bytes, max_bytes) {
-        (_, Some(max)) if file_size > max => Err(ServiceError::FileTooLarge(max)),
-        (Some(min), _) if file_size < min => Err(ServiceError::FileTooSmall(min)),
-        _ => Ok(()),
     }
 }
 

--- a/src/tools/directory_tree.rs
+++ b/src/tools/directory_tree.rs
@@ -39,16 +39,14 @@ impl DirectoryTree {
     ) -> std::result::Result<CallToolResult, CallToolError> {
         let mut entry_counter: usize = 0;
 
-        let allowed_directories = context.allowed_directories().await;
-
         let (entries, reached_max_depth) = context
             .directory_tree(
                 params.path,
                 params.max_depth.map(|v| v as usize),
                 None,
                 &mut entry_counter,
-                allowed_directories,
             )
+            .await
             .map_err(CallToolError::new)?;
 
         if entry_counter == 0 {

--- a/src/tools/list_directory.rs
+++ b/src/tools/list_directory.rs
@@ -44,12 +44,12 @@ impl ListDirectory {
             .map(|entry| {
                 format!(
                     "{} {}",
-                    if entry.path().is_dir() {
+                    if entry.is_dir() {
                         "[DIR]"
                     } else {
                         "[FILE]"
                     },
-                    entry.file_name().to_str().unwrap_or_default()
+                    entry.file_name()
                 )
             })
             .collect();

--- a/src/tools/list_directory.rs
+++ b/src/tools/list_directory.rs
@@ -44,11 +44,7 @@ impl ListDirectory {
             .map(|entry| {
                 format!(
                     "{} {}",
-                    if entry.is_dir() {
-                        "[DIR]"
-                    } else {
-                        "[FILE]"
-                    },
+                    if entry.is_dir() { "[DIR]" } else { "[FILE]" },
                     entry.file_name()
                 )
             })

--- a/src/tools/list_directory_with_sizes.rs
+++ b/src/tools/list_directory_with_sizes.rs
@@ -5,8 +5,8 @@ use std::fmt::Write;
 use std::path::Path;
 
 use crate::fs_service::FileSystemService;
-use crate::fs_service::utils::format_bytes;
 use crate::fs_service::FsEntry;
+use crate::fs_service::utils::format_bytes;
 
 #[mcp_tool(
     name = "list_directory_with_sizes",

--- a/src/tools/list_directory_with_sizes.rs
+++ b/src/tools/list_directory_with_sizes.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 use crate::fs_service::FileSystemService;
 use crate::fs_service::utils::format_bytes;
+use crate::fs_service::FsEntry;
 
 #[mcp_tool(
     name = "list_directory_with_sizes",
@@ -31,9 +32,9 @@ pub struct ListDirectoryWithSizes {
 }
 
 impl ListDirectoryWithSizes {
-    async fn format_directory_entries(
+    fn format_directory_entries(
         &self,
-        mut entries: Vec<tokio::fs::DirEntry>,
+        mut entries: Vec<FsEntry>,
     ) -> std::result::Result<String, CallToolError> {
         let mut file_count = 0;
         let mut dir_count = 0;
@@ -43,20 +44,17 @@ impl ListDirectoryWithSizes {
         let mut output = String::with_capacity(entries.len() * 50 + 120);
 
         // Sort entries by file name
-        entries.sort_by_key(|a| a.file_name());
+        entries.sort_by(|a, b| a.file_name().cmp(b.file_name()));
 
         // build the output string
         for entry in &entries {
             let file_name = entry.file_name();
-            let file_name = file_name.to_string_lossy();
 
-            if entry.path().is_dir() {
+            if entry.is_dir() {
                 writeln!(output, "[DIR]  {file_name:<30}").map_err(CallToolError::new)?;
                 dir_count += 1;
-            } else if entry.path().is_file() {
-                let metadata = entry.metadata().await.map_err(CallToolError::new)?;
-
-                let file_size = metadata.len();
+            } else if entry.is_file() {
+                let file_size = entry.len();
                 writeln!(
                     output,
                     "[FILE] {:<30} {:>10}",
@@ -91,7 +89,6 @@ impl ListDirectoryWithSizes {
 
         let output = params
             .format_directory_entries(entries)
-            .await
             .map_err(CallToolError::new)?;
         Ok(CallToolResult::text_content(vec![TextContent::from(
             output,

--- a/tests/test_fs_service.rs
+++ b/tests/test_fs_service.rs
@@ -56,33 +56,33 @@ async fn test_allowed_directories() {
 
 #[tokio::test]
 async fn test_validate_path_allowed() {
-    let (temp_dir, service, allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
     let file_path = temp_dir.join("dir1").join("test.txt");
     create_temp_file(temp_dir.join("dir1").as_path(), "test.txt", "content");
-    let result = service.validate_path(&file_path, allowed_dirs);
+    let result = service.resolve(&file_path).await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), file_path);
+    assert_eq!(result.unwrap().display, file_path);
 }
 
 #[tokio::test]
 async fn test_validate_path_denied() {
-    let (temp_dir, service, allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
     let outside_path = temp_dir.join("dir2").join("test.txt");
-    let result = service.validate_path(&outside_path, allowed_dirs);
+    let result = service.resolve(&outside_path).await;
     assert!(matches!(result, Err(ServiceError::FromString(_))));
 }
 
 #[tokio::test]
 async fn test_path_traversal_rejected() {
     // CVE-style PoC: ../.. escape from inside the allowed root must be denied.
-    let (temp_dir, service, allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
     let traversal = temp_dir
         .join("dir1")
         .join("..")
         .join("..")
         .join("dir2")
         .join("pwned.txt");
-    let result = service.validate_path(&traversal, allowed_dirs);
+    let result = service.resolve(&traversal).await;
     assert!(matches!(result, Err(ServiceError::FromString(_))));
 }
 
@@ -90,12 +90,12 @@ async fn test_path_traversal_rejected() {
 #[tokio::test]
 async fn test_path_traversal_with_symlink_rejected() {
     // Symlink in the allowed root pointing outside must be rejected for writes.
-    let (temp_dir, service, allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
     let outside = temp_dir.join("dir2");
     std::fs::create_dir(&outside).unwrap();
     let symlink_path = temp_dir.join("dir1").join("link");
     std::os::unix::fs::symlink(&outside, &symlink_path).unwrap();
-    let result = service.validate_path(&symlink_path.join("target.txt"), allowed_dirs);
+    let result = service.resolve(&symlink_path.join("target.txt")).await;
     assert!(matches!(result, Err(ServiceError::FromString(_))));
 }
 
@@ -166,7 +166,7 @@ async fn test_path_traversal_via_edit_save_to_rejected() {
 
 #[tokio::test]
 async fn test_path_traversal_multiple_parent_dirs_rejected() {
-    let (temp_dir, service, allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
     let traversal = temp_dir
         .join("dir1")
         .join("..")
@@ -175,47 +175,47 @@ async fn test_path_traversal_multiple_parent_dirs_rejected() {
         .join("..")
         .join("etc")
         .join("passwd");
-    let result = service.validate_path(&traversal, allowed_dirs);
+    let result = service.resolve(&traversal).await;
     assert!(matches!(result, Err(ServiceError::FromString(_))));
 }
 
 #[tokio::test]
 async fn test_path_traversal_existing_parent_resolves_correctly() {
     // Path with .. that canonicalizes to inside the allowed root should still work.
-    let (temp_dir, service, allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
     let sub_dir = temp_dir.join("dir1").join("subdir");
     std::fs::create_dir(&sub_dir).unwrap();
     let file_path = sub_dir.join("..").join("subdir").join("test.txt");
     create_temp_file(&sub_dir, "test.txt", "content");
-    let result = service.validate_path(&file_path, allowed_dirs);
+    let result = service.resolve(&file_path).await;
     assert!(result.is_ok());
-    assert_eq!(result.unwrap(), sub_dir.join("test.txt"));
+    assert_eq!(result.unwrap().display, sub_dir.join("test.txt"));
 }
 
 #[tokio::test]
 async fn test_path_traversal_nonexistent_with_existing_parent_rejected() {
     // Non-existent write target whose parent resolves outside the allowed root.
-    let (temp_dir, service, allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
     let traversal = temp_dir
         .join("dir1")
         .join("..")
         .join("..")
         .join("dir2")
         .join("pwned.txt");
-    let result = service.validate_path(&traversal, allowed_dirs);
+    let result = service.resolve(&traversal).await;
     assert!(matches!(result, Err(ServiceError::FromString(_))));
 }
 
 #[tokio::test]
 async fn test_path_traversal_defence_in_depth_parent_dir() {
     // Defense-in-depth: even if normalization somehow leaves .., reject it.
-    let (temp_dir, service, allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
     let traversal = temp_dir
         .join("dir1")
         .join("..")
         .join("dir2")
         .join("pwned.txt");
-    let result = service.validate_path(&traversal, allowed_dirs);
+    let result = service.resolve(&traversal).await;
     assert!(matches!(result, Err(ServiceError::FromString(_))));
     // And the path itself should not have been created
     assert!(!traversal.exists());
@@ -249,15 +249,13 @@ fn test_normalize_windows_drive_path_for_mounted_roots() {
 #[tokio::test]
 async fn test_validate_path_accepts_native_windows_path_inside_mounted_root() {
     let service = FileSystemService::try_new(&["/".to_string()]).unwrap();
-    let allowed_dirs = std::sync::Arc::new(vec![PathBuf::from("/mnt/c/Users/Peter/IdeaProjects")]);
 
-    let result = service.validate_path(
-        Path::new(r"C:\Users\Peter\IdeaProjects\WashlyServer\src\main.rs"),
-        allowed_dirs,
-    );
+    let result = service
+        .resolve(Path::new(r"C:\Users\Peter\IdeaProjects\WashlyServer\src\main.rs"))
+        .await;
 
     assert_eq!(
-        result.unwrap(),
+        result.unwrap().display,
         PathBuf::from("/mnt/c/Users/Peter/IdeaProjects/WashlyServer/src/main.rs")
     );
 }
@@ -265,13 +263,12 @@ async fn test_validate_path_accepts_native_windows_path_inside_mounted_root() {
 #[cfg(not(windows))]
 #[tokio::test]
 async fn test_validate_path_rejects_native_windows_path_outside_mounted_root() {
-    let service = FileSystemService::try_new(&["/".to_string()]).unwrap();
-    let allowed_dirs = std::sync::Arc::new(vec![PathBuf::from("/mnt/c/Users/Peter/IdeaProjects")]);
+    let temp_dir = get_temp_dir();
+    let service = FileSystemService::try_new(&[temp_dir.to_str().unwrap().to_string()]).unwrap();
 
-    let result = service.validate_path(
-        Path::new(r"C:\Users\Peter\Downloads\outside.txt"),
-        allowed_dirs,
-    );
+    let result = service
+        .resolve(Path::new(r"C:\Users\Peter\Downloads\outside.txt"))
+        .await;
 
     assert!(matches!(result, Err(ServiceError::FromString(_))));
 }
@@ -284,9 +281,10 @@ async fn test_windows_drive_path_with_real_dir() {
     std::fs::create_dir(&sub_dir).unwrap();
 
     let service = FileSystemService::try_new(&[sub_dir.to_str().unwrap().to_string()]).unwrap();
-    let allowed_dirs = std::sync::Arc::new(vec![sub_dir.clone()]);
 
-    let result = service.validate_path(Path::new(r"C:\does_not_exist\test.txt"), allowed_dirs);
+    let result = service
+        .resolve(Path::new(r"C:\does_not_exist\test.txt"))
+        .await;
 
     assert!(matches!(result, Err(ServiceError::FromString(_))));
 }
@@ -298,26 +296,60 @@ fn test_normalize_line_endings() {
     assert_eq!(normalized, "line1\nline2\nline3");
 }
 
-#[test]
-fn test_contains_symlink_no_symlink() {
-    let temp_dir = get_temp_dir();
-    let file_path = create_temp_file(&temp_dir, "test.txt", "content");
-    let result = contains_symlink(file_path).unwrap();
-    assert!(!result);
+#[cfg(unix)]
+#[tokio::test]
+async fn test_dangling_symlink_write_escape_rejected() {
+    // Reporter PoC: a dangling symlink inside the allowed dir pointing outside
+    // must not let write_file create the target file outside the sandbox.
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let outside = temp_dir.join("outside");
+    std::fs::create_dir(&outside).unwrap();
+    let outside_target = outside.join("pwned.txt");
+    let link_path = temp_dir.join("dir1").join("link");
+    std::os::unix::fs::symlink(&outside_target, &link_path).unwrap();
+
+    let result = service
+        .write_file(&link_path, &"PWNED-VIA-SYMLINK-ESCAPE".to_string())
+        .await;
+
+    assert!(result.is_err());
+    assert!(!outside_target.exists());
 }
 
-// Symlink test is platform-dependent , it require administrator privileges on some systems
 #[cfg(unix)]
-#[test]
-fn test_contains_symlink_with_symlink() {
-    use common::create_temp_file;
+#[tokio::test]
+async fn test_write_file_through_symlink_to_existing_outside_rejected() {
+    // A symlink to an existing file outside the sandbox must not be writable.
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let outside = temp_dir.join("outside");
+    std::fs::create_dir(&outside).unwrap();
+    let outside_target = outside.join("pwned.txt");
+    std::fs::write(&outside_target, "original").unwrap();
+    let link_path = temp_dir.join("dir1").join("link");
+    std::os::unix::fs::symlink(&outside_target, &link_path).unwrap();
 
-    let temp_dir = get_temp_dir();
-    let target_path = create_temp_file(&temp_dir, "target.txt", "content");
-    let link_path = temp_dir.join("link.txt");
-    std::os::unix::fs::symlink(&target_path, &link_path).unwrap();
-    let result = contains_symlink(&link_path).unwrap();
-    assert!(result);
+    let result = service
+        .write_file(&link_path, &"PWNED-VIA-SYMLINK-ESCAPE".to_string())
+        .await;
+
+    assert!(result.is_err());
+    assert_eq!(std::fs::read_to_string(&outside_target).unwrap(), "original");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_create_directory_through_symlink_rejected() {
+    // create_directory must not follow a symlink out of the sandbox.
+    let (temp_dir, service, _allowed_dirs) = setup_service(vec!["dir1".to_string()]);
+    let outside = temp_dir.join("outside");
+    std::fs::create_dir(&outside).unwrap();
+    let link_path = temp_dir.join("dir1").join("link");
+    std::os::unix::fs::symlink(&outside, &link_path).unwrap();
+
+    let result = service.create_directory(&link_path.join("sub")).await;
+
+    assert!(result.is_err());
+    assert!(!outside.join("sub").exists());
 }
 
 #[tokio::test]
@@ -592,7 +624,7 @@ async fn test_list_directory() {
     let entries = service.list_directory(&dir_path).await.unwrap();
     let names: Vec<_> = entries
         .into_iter()
-        .map(|e| e.file_name().to_str().unwrap().to_string())
+        .map(|e| e.file_name().to_string())
         .collect();
     assert_eq!(names.len(), 2);
     assert!(names.contains(&"file1.txt".to_string()));
@@ -621,7 +653,7 @@ async fn test_search_files() {
         .unwrap();
     let names: Vec<_> = result
         .into_iter()
-        .map(|e| e.file_name().to_str().unwrap().to_string())
+        .map(|e| e.file_name().to_string())
         .collect();
     assert_eq!(names, vec!["test1.txt"]);
 }
@@ -644,7 +676,7 @@ async fn test_search_files_with_exclude() {
         .unwrap();
     let names: Vec<_> = result
         .into_iter()
-        .map(|e| e.file_name().to_str().unwrap().to_string())
+        .map(|e| e.file_name().to_string())
         .collect();
     assert_eq!(names, vec!["test1.txt"]);
 }
@@ -779,21 +811,6 @@ fn test_format_permissions_windows() {
     let dir_metadata = fs::metadata(temp_dir).unwrap();
     let dir_formatted = format_permissions(&dir_metadata);
     assert_eq!(dir_formatted, "dw"); // Directory, typically writable
-}
-
-#[test]
-fn test_normalize_path() {
-    let temp_dir = get_temp_dir();
-    let file_path = temp_dir.join("test.txt");
-    File::create(&file_path).unwrap();
-
-    let normalized = normalize_path(&file_path);
-    assert_eq!(normalized, file_path);
-
-    // Test non-existent path
-    let non_existent = Path::new("/does/not/exist");
-    let normalized_non_existent = normalize_path(non_existent);
-    assert_eq!(normalized_non_existent, non_existent.to_path_buf());
 }
 
 #[test]
@@ -1061,7 +1078,7 @@ async fn test_exact_match() {
 
     let file = create_temp_file(
         &temp_dir.as_path().join("dir1"),
-        "tets_file1.txt",
+        "test_file1.txt",
         "hello world\n",
     );
 
@@ -1412,7 +1429,7 @@ async fn test_content_search() {
     let query = r#"Watso\d*n"#;
 
     // search as regex
-    let result = service.content_search(query, &file, Some(true)).unwrap();
+    let result = service.content_search(query, &file, Some(true)).await.unwrap();
 
     assert!(result.is_some());
     let result = result.unwrap();
@@ -1431,7 +1448,7 @@ async fn test_content_search() {
     );
 
     // search as literal
-    let result = service.content_search(query, &file, Some(false)).unwrap();
+    let result = service.content_search(query, &file, Some(false)).await.unwrap();
     assert!(result.is_some());
     let result = result.unwrap();
     assert_eq!(result.matches.len(), 1);
@@ -2357,7 +2374,7 @@ async fn test_search_files_brace_expanded_github_issue_50() {
 
     let names: Vec<_> = result
         .into_iter()
-        .map(|e| e.file_name().to_str().unwrap().to_string())
+        .map(|e| e.file_name().to_string())
         .collect();
 
     assert!(names.iter().all(|name| {

--- a/tests/test_fs_service.rs
+++ b/tests/test_fs_service.rs
@@ -251,7 +251,9 @@ async fn test_validate_path_accepts_native_windows_path_inside_mounted_root() {
     let service = FileSystemService::try_new(&["/".to_string()]).unwrap();
 
     let result = service
-        .resolve(Path::new(r"C:\Users\Peter\IdeaProjects\WashlyServer\src\main.rs"))
+        .resolve(Path::new(
+            r"C:\Users\Peter\IdeaProjects\WashlyServer\src\main.rs",
+        ))
         .await;
 
     assert_eq!(
@@ -333,7 +335,10 @@ async fn test_write_file_through_symlink_to_existing_outside_rejected() {
         .await;
 
     assert!(result.is_err());
-    assert_eq!(std::fs::read_to_string(&outside_target).unwrap(), "original");
+    assert_eq!(
+        std::fs::read_to_string(&outside_target).unwrap(),
+        "original"
+    );
 }
 
 #[cfg(unix)]
@@ -1429,7 +1434,10 @@ async fn test_content_search() {
     let query = r#"Watso\d*n"#;
 
     // search as regex
-    let result = service.content_search(query, &file, Some(true)).await.unwrap();
+    let result = service
+        .content_search(query, &file, Some(true))
+        .await
+        .unwrap();
 
     assert!(result.is_some());
     let result = result.unwrap();
@@ -1448,7 +1456,10 @@ async fn test_content_search() {
     );
 
     // search as literal
-    let result = service.content_search(query, &file, Some(false)).await.unwrap();
+    let result = service
+        .content_search(query, &file, Some(false))
+        .await
+        .unwrap();
     assert!(result.is_some());
     let result = result.unwrap();
     assert_eq!(result.matches.len(), 1);


### PR DESCRIPTION
### 📌 Summary
Migrate all filesystem access to `cap-std`'s handle-based `Dir` API to eliminate the symlink path-traversal / dangling symlink escape class.
with `cap-std` each allowed directory is opened once into a handle all operations inherit, confining I/O to an already-open Dir and structurally eliminating symlink/TOCTOU escapes , no feature or perf cost.


### 🔍 Related Issues
<!-- Link related issues using keywords like "Fixes #123" or "Closes #456" -->

- #91 

### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Add `cap-std` dependency and remove `walkdir`.
- Update `fs_service::core`.
- Migrate `io/{read,write,edit}`, `search/{files,tree,content}` and
  `archive/{zip,unzip}` to `cap_std::fs::Dir.
- Removed unsafe path helpers (`normalize_path`, `contains_symlink`,
  `read_file_as_base64`, `mime_from_path`, `validate_file_size`)
-  Qdded `mime_from_bytes`, `encode_base64`.
- Updated consumers (`list_directory`, `list_directory_with_sizes`,
  `directory_tree`) for the new API.
- Add regression tests.


### 🛠️ Testing Steps
```bash
cargo make check
```
